### PR TITLE
dp-grpc #116: ingestion API column metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+### Project planning and development artifacts ###
+.dev/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This repo defines the gRPC API for the **Machine Learning Data Platform (MLDP)**
 
 - **GitHub**: https://github.com/osprey-dcs/dp-grpc
 - **Project home**: https://github.com/osprey-dcs/data-platform
-- **Java package**: `com.ospreydcs.dp.grpc.v1`
+- **Java package prefix**: `com.ospreydcs.dp.grpc.v1` (generated classes use service-scoped packages such as `com.ospreydcs.dp.grpc.v1.common`, `.query`, `.ingestion`, `.annotation`, and `.ingestion_stream`)
 - **Maven coordinates**: `com.ospreydcs:dp-grpc` (see `pom.xml` for current version)
 - **Java target**: 21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# dp-grpc — Claude Code Context
+
+## Project Overview
+
+This repo defines the gRPC API for the **Machine Learning Data Platform (MLDP)** — a high-performance archive for PV (process variable) time-series data from large-scale research facilities such as particle accelerators. The project produces a JAR of compiled Java stubs generated from the proto files; it does not run as a standalone service.
+
+- **GitHub**: https://github.com/osprey-dcs/dp-grpc
+- **Project home**: https://github.com/osprey-dcs/data-platform
+- **Java package**: `com.ospreydcs.dp.grpc.v1`
+- **Maven coordinates**: `com.ospreydcs:dp-grpc` (see `pom.xml` for current version)
+- **Java target**: 21
+
+## Repository Layout
+
+```
+src/main/proto/       # All proto files (the primary artifact of this repo)
+doc/                  # Images and proposed/design proto files
+.dev/plan/            # Planning documents (gitignored)
+pom.xml               # Maven build; runs protoc via protobuf-maven-plugin
+```
+
+## Proto Files
+
+| File | Purpose |
+|---|---|
+| `common.proto` | Shared data structures used by all services |
+| `ingestion.proto` | DpIngestionService — provider registration, data ingestion, subscriptions, request status |
+| `query.proto` | DpQueryService — time-series data query, PV metadata query, provider query |
+| `annotation.proto` | DpAnnotationService — DataSets, Annotations, Calculations, data export |
+| `ingestion_stream.proto` | DpIngestionStreamService — data event subscriptions |
+
+Proto files are compiled by the `protobuf-maven-plugin` (0.6.1) using `protoc` and `grpc-java`. Generated Java sources land in `target/generated-sources/`.
+
+## Key Concepts
+
+### Column Messages (`common.proto`)
+Data is stored and transmitted in **column-oriented** vectors, one column per PV per request. Column message types:
+
+- **Scalar**: `DoubleColumn`, `FloatColumn`, `Int64Column`, `Int32Column`, `BoolColumn`, `StringColumn`, `EnumColumn`
+- **Array**: `DoubleArrayColumn`, `FloatArrayColumn`, `Int64ArrayColumn`, `Int32ArrayColumn`, `BoolArrayColumn`
+- **Complex**: `ImageColumn`, `StructColumn`, `SerializedDataColumn`
+- **Deprecated**: `DataColumn` / `DataValue` (per-sample allocation; avoid for new ingestion)
+
+Each column message carries an optional `ColumnMetadata metadata = 10` field (added in issue #116) containing `ColumnProvenance` (source/process), `tags`, and `attributes`.
+
+### DataFrame (`common.proto`)
+The unit of ingestion. Contains `DataTimestamps` (either a `SamplingClock` or explicit `TimestampList`) plus lists of the column message types above.
+
+### DataBucket (`common.proto`)
+The unit of query results. One PV, one time range, one column message (via `DataValues` oneof).
+
+### DataTimestamps (`common.proto`)
+Two modes:
+- `SamplingClock` — start time + period (nanos) + count (uniform sampling)
+- `TimestampList` — explicit list of `Timestamp` messages
+
+### Bucket Pattern
+Ingestion and storage use the [MongoDB bucket pattern](https://www.mongodb.com/blog/post/building-with-patterns-the-bucket-pattern): all sample values for a PV over a time range are stored as a single record, not one record per sample.
+
+### Asynchronous Ingestion
+Ingestion responses only confirm acceptance/rejection. Actual persistence is async. Use `queryRequestStatus()` to check outcomes.
+
+### Response Pattern
+All response messages use a `oneof result` with either `ExceptionalResult` (rejection/error) or a method-specific success payload.
+
+## Services
+
+### DpIngestionService (`ingestion.proto`)
+- `registerProvider` — must be called before ingesting; safe to call on every client startup
+- `ingestData` / `ingestDataStream` / `ingestDataBidiStream` — unary / client-streaming / bidi-streaming ingestion
+- `subscribeData` — bidi-stream subscription to live PV data from the ingestion pipeline
+- `queryRequestStatus` — check async ingestion request outcomes
+
+### DpQueryService (`query.proto`)
+- `queryData` / `queryDataStream` / `queryDataBidiStream` / `queryTable` — retrieve archived time-series data
+- `queryPvMetadata` — PV archive metadata (first/last timestamp, data type, bucket stats)
+- `queryProviders` — find providers by id, text, tags, attributes
+- `queryProviderMetadata` — ingestion statistics for a provider
+
+### DpAnnotationService (`annotation.proto`)
+- `createDataSet` / `queryDataSets` — manage DataSets (blocks of PVs × time ranges)
+- `createAnnotation` / `queryAnnotations` — manage Annotations (text, tags, attributes, Calculations, provenance)
+- `exportData` — export DataSets and/or Calculations to HDF5, CSV, or XLSX
+
+### DpIngestionStreamService (`ingestion_stream.proto`)
+- `subscribeDataEvent` — bidi-stream subscription that fires when a `PvConditionTrigger` condition is met in the live ingestion stream, optionally returning EventData for a time window around the trigger
+
+## Proto Conventions
+
+- Elements within a proto file are ordered: service definition → request/response messages → supporting types.
+- All method parameters are bundled into a single `*Request` message.
+- Request/response message names mirror the method name (e.g., `registerProvider` → `RegisterProviderRequest` / `RegisterProviderResponse`).
+- Shared messages go in `common.proto`; service-scoped messages stay in the service's proto file.
+- Nested messages are used to limit scope where the type is only used within one parent message.
+- Empty query results return an empty list in the result payload, not an `ExceptionalResult`.
+
+## Build
+
+```bash
+mvn compile          # compile proto files and generate Java stubs
+mvn package          # build the JAR
+```
+
+Generated Java sources appear in `target/generated-sources/protobuf/`.
+
+## Releases
+
+Tagged as `rel-<version>`. Release artifacts (JAR + SHA-256 checksum) are attached to GitHub releases. See `README.env` for download and verification instructions.
+
+## Planning Artifacts
+
+Design documents and implementation plans are stored under `.dev/plan/issue-<N>/` and are gitignored.

--- a/README.md
+++ b/README.md
@@ -223,9 +223,17 @@ It is assumed that each PV for a particular facility is uniquely named.  E.g., "
 
 The Ingestion and Query Service APIs for handling data work with vectors of PV samples.  In ___common.proto___, there are a number of column messages optimized for handling a range of heterogeneous data types.
 
-Messages for vectors of individual scalar values include DoubleColumn, FloatColumn, Int64Column, Int32Column, BoolColumn, with corresponding messages for handling samples that are arrays of scalar values DoubleArrayColumn, FloatArrayColumn, Int64ArrayColumn, Int32ArrayColumn, and BoolArrayColumn.  Messages are provided for other data types including StringColumn, EnumColumn, ImageColumn, and StructColumn.  The SerializedDataColumn message is used to contain arbitrary binary data with user-defined encoding.
+Messages for vectors of individual scalar values include DoubleColumn, FloatColumn, Int64Column, Int32Column, BoolColumn, with corresponding messages for handling samples that are arrays of scalar values DoubleArrayColumn, FloatArrayColumn, Int64ArrayColumn, Int32ArrayColumn, and BoolArrayColumn.  Messages are provided for other data types including StringColumn, EnumColumn, ImageColumn, and StructColumn.  The SerializedDataColumn message is used to contain arbitrary binary data with user-defined encoding.  Each column message includes an optional ColumnMetadata field for per-column provenance, tags, and attributes (see below).
 
 The original implementation includes the message DataColumn which contains a list of DataValue messages, where each DataValue specifies a heterogeneous data type for the sample value.  This feature is deprecated in the Ingestion Service API because 1) it causes per-sample JVM memory allocation in handling ingestion requests and 2) all sample values (including scalars) are stored as opaque binary blobs in the archive.
+
+#### column metadata and provenance
+
+Each column message includes an optional ColumnMetadata field for attaching per-column metadata to an ingestion request.  ColumnMetadata contains a ColumnProvenance message, a list of string tags, and a list of key/value Attribute pairs.
+
+ColumnProvenance has two unconstrained, facility-specific string fields: "source", which identifies the origin of the data (e.g., an NTTable/column identifier), and "process", which describes any processing applied to the source data (e.g., normalization).  The MLDP does not constrain, enforce, or otherwise interpret these values.
+
+Column metadata is truly dynamic — it travels with each ingestion request and is stored at the bucket level.  For more static PV information, use the PV metadata query API.  Overuse of bucket-level metadata will burden the ingestion server process, which is optimized for continually ingesting PV time-series data.
 
 #### timestamps
 
@@ -302,7 +310,7 @@ The API provides three methods for data ingestion, including a simple unary sing
 
 ----
 
-All data ingestion methods share the same request message, IngestDataRequest.  An IngestDataRequest contains the data to be ingested to the archive along with some required identifying information and optional descriptive fields.  The unit of ingestion is the DataFrame.  Analogous to a worksheet in an Excel workbook, DataFrame contains 1) a DataTimestamps object specifying the timestamp rows for the worksheet and 2) lists of heterogeneous column messages each of which is a column vector of data values, one for each timestamp row in the worksheet.
+All data ingestion methods share the same request message, IngestDataRequest.  An IngestDataRequest contains the data to be ingested to the archive along with some required identifying information and optional descriptive fields.  The unit of ingestion is the DataFrame.  Analogous to a worksheet in an Excel workbook, DataFrame contains 1) a DataTimestamps object specifying the timestamp rows for the worksheet and 2) lists of heterogeneous column messages each of which is a column vector of data values, one for each timestamp row in the worksheet.  Each column message in the DataFrame may optionally include a ColumnMetadata field containing provenance information, tags, and key/value attributes that are stored at the bucket level in the archive.
 
 ----
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ospreydcs</groupId>
     <artifactId>dp-grpc</artifactId>
     <packaging>jar</packaging>
-    <version>1.13.0</version>
+    <version>1.14.0</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -30,7 +30,7 @@ message Attribute {
  * The "source" identifies the origin of the data (e.g., an NTTable/column identifier), and the
  * "process" describes any processing applied to the source data (e.g., normalization).
  * The MLDP does not constrain, enforce, or otherwise interpret these values.
- * Empty string values for either field are ignored by the MLDP.
+ * Clients should omit unset provenance fields rather than sending empty string values.
  */
 message ColumnProvenance {
   string source = 1;

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -23,6 +23,33 @@ message Attribute {
   string value = 2;
 }
 
+/*
+ * ColumnProvenance
+ *
+ * Describes the provenance of a data column. These fields are unconstrained and facility-specific.
+ * The "source" identifies the origin of the data (e.g., an NTTable/column identifier), and the
+ * "process" describes any processing applied to the source data (e.g., normalization).
+ * The MLDP does not constrain, enforce, or otherwise interpret these values.
+ */
+message ColumnProvenance {
+  string source = 1;
+  string process = 2;
+}
+
+/*
+ * ColumnMetadata
+ *
+ * Wrapper for optional column-level metadata included with an ingestion request.
+ * Includes provenance information, a list of string tags, and a list of key-value attributes.
+ * Overuse of bucket-level metadata will burden the ingestion server process, which is
+ * optimized for continually ingesting PV time-series data.
+ */
+message ColumnMetadata {
+  ColumnProvenance provenance = 1;
+  repeated string tags = 2;
+  repeated Attribute attributes = 3;
+}
+
 //
 // ------------------- Time Definitions ---------------------------
 //
@@ -114,6 +141,7 @@ message ExceptionalResult {
 message DoubleColumn {
   string name = 1; // PV name
   repeated double values = 2 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -124,6 +152,7 @@ message DoubleColumn {
 message FloatColumn {
   string name = 1; // PV name
   repeated float values = 2 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -134,6 +163,7 @@ message FloatColumn {
 message Int64Column {
   string name = 1; // PV name
   repeated sint64 values = 2 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -144,6 +174,7 @@ message Int64Column {
 message Int32Column {
   string name = 1; // PV name
   repeated sint32 values = 2 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -154,6 +185,7 @@ message Int32Column {
 message BoolColumn {
   string name = 1; // PV name
   repeated bool values = 2 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -166,6 +198,7 @@ message BoolColumn {
 message StringColumn {
   string name = 1; // PV name
   repeated string values = 2;
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -179,6 +212,7 @@ message EnumColumn {
   string name = 1; // PV name
   repeated int32 values = 2 [packed = true];
   string enumId = 3; // identifier for enum semantics, e.g. "epics:alarm_status:v2"
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -202,6 +236,7 @@ message DoubleArrayColumn {
   ArrayDimensions dimensions = 2;
   // Flattened: sample_count × product(dims)
   repeated double values = 3 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -214,6 +249,7 @@ message FloatArrayColumn {
   string name = 1;
   ArrayDimensions dimensions = 2;
   repeated float values = 3 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -226,6 +262,7 @@ message Int64ArrayColumn {
   string name = 1;
   ArrayDimensions dimensions = 2;
   repeated sint64 values = 3 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -238,6 +275,7 @@ message Int32ArrayColumn {
   string name = 1;
   ArrayDimensions dimensions = 2;
   repeated sint32 values = 3 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -250,6 +288,7 @@ message BoolArrayColumn {
   string name = 1;
   ArrayDimensions dimensions = 2;
   repeated bool values = 3 [packed = true];
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -276,6 +315,7 @@ message ImageColumn {
   ImageDescriptor imageDescriptor = 2;
   // One image per sample
   repeated bytes images = 3;
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -290,6 +330,7 @@ message StructColumn {
   string schemaId = 2; // e.g. "beam_position:v3"
   // One struct per sample
   repeated bytes values = 3;
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -302,6 +343,7 @@ message SerializedDataColumn {
   string name = 1;
   string encoding = 2; // e.g. "Image:v1", "Struct:BeamPosition:v2", "proto:Image".
   bytes payload = 3;
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*
@@ -318,6 +360,7 @@ message SerializedDataColumn {
 message DataColumn {
   string name = 1; // Name of PV.
   repeated DataValue dataValues = 2; // List of heterogeneous column data values.
+  ColumnMetadata metadata = 10; // optional
 }
 
 /*

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -42,7 +42,7 @@ message ColumnProvenance {
  *
  * Wrapper for optional column-level metadata included with an ingestion request.
  * Includes provenance information, a list of string tags, and a list of key-value attributes.
- * Overuse of bucket-level metadata will burden the ingestion server process, which is
+ * Overuse of per-request column metadata will burden the ingestion server process, which is
  * optimized for continually ingesting PV time-series data.
  */
 message ColumnMetadata {

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -30,6 +30,7 @@ message Attribute {
  * The "source" identifies the origin of the data (e.g., an NTTable/column identifier), and the
  * "process" describes any processing applied to the source data (e.g., normalization).
  * The MLDP does not constrain, enforce, or otherwise interpret these values.
+ * Empty string values for either field are ignored by the MLDP.
  */
 message ColumnProvenance {
   string source = 1;
@@ -571,7 +572,8 @@ message DataFrame {
  *
  * Contains bucketed time-series data for a PV over a time period as specified in the dataTimestamps. Includes
  * a DataTimestamps message specifying the timestamps for the individual data values, and a heterogeneous column
- * message containing the vector of data values with one value per timestamp.
+ * message containing the vector of data values with one value per timestamp. If ColumnMetadata was supplied
+ * for the column at ingestion time, it is stored with the bucket and returned in the embedded column message.
  */
 message DataBucket {
   string pvName = 1; // Name of PV for data column.

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -188,8 +188,9 @@ message QueryDataResponse {
    * Contains the data for a time series data query result, as a list of DataBucket objects. Each DataBucket minimally
    * includes a vector of PV data values (in a DataColumn) and a DataTimestamps object specifying the timestamps
    * for the data vector values using either a SamplingClock (with start time, sample period, and number of samples or
-   * an explicit list of timestamps) or a TimestampsList (with an explicit list of timestamps). The DataBucket also
-   * includes key/value Attributes and/or EventMetadata if defined for the data in ingestion.
+   * an explicit list of timestamps) or a TimestampsList (with an explicit list of timestamps). If ColumnMetadata
+   * (including provenance, tags, and/or attributes) was supplied for the column at ingestion time, it is returned
+   * in the embedded column message within the DataBucket.
    *
    * By default, each DataBucket contains a regular DataColumn object with the vector of data for the bucket.
    * if the useSerializedDataColumns flag is set in the QueryDataRequest's QuerySpec, each DataBucket in the result

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -188,7 +188,7 @@ message QueryDataResponse {
    * Contains the data for a time series data query result, as a list of DataBucket objects. Each DataBucket minimally
    * includes a vector of PV data values (in a DataColumn) and a DataTimestamps object specifying the timestamps
    * for the data vector values using either a SamplingClock (with start time, sample period, and number of samples or
-   * an explicit list of timestamps) or a TimestampsList (with an explicit list of timestamps). If ColumnMetadata
+   * an explicit list of timestamps) or a TimestampList (with an explicit list of timestamps). If ColumnMetadata
    * (including provenance, tags, and/or attributes) was supplied for the column at ingestion time, it is returned
    * in the embedded column message within the DataBucket.
    *


### PR DESCRIPTION
This PR includes API changes to add facilities for capturing column level metadata in data ingestion requests.  This was accomplished in issue #116 which added a new ColumnMetadata message with a nested ColumnProvenanceMessage, and modified each of the column message types to include a nested ColumnMetadata object.