### PR TITLE
dp-grpc #117 proto changes for PV metadata API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Metadata APIs follow a standard CRUD method set. `DpAnnotationService.savePvMeta
 | `get*` | Single-record lookup by primary key | Implemented |
 | `delete*` | Delete record by primary key | Implemented |
 | `patch*` | Partial update via field mask | Deferred (see below) |
-| `bulk Save*` | Bulk full-replace upsert for large imports | Deferred (see below) |
+| `bulkSave*` | Bulk full-replace upsert for large imports | Deferred (see below) |
 
 **Pagination** (`query*` methods): use `uint32 limit` + `string pageToken` in the request
 and `string nextPageToken` in the result message. An empty `nextPageToken` signals the last

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,60 @@ All response messages use a `oneof result` with either `ExceptionalResult` (reje
 - Nested messages are used to limit scope where the type is only used within one parent message.
 - Empty query results return an empty list in the result payload, not an `ExceptionalResult`.
 
+### CRUD Pattern for Metadata APIs
+
+Metadata APIs follow a standard CRUD method set. `DpAnnotationService.savePvMetadata` /
+`queryPvMetadata` / `getPvMetadata` / `deletePvMetadata` / `patchPvMetadata` /
+`bulkSavePvMetadata` is the reference implementation of this pattern.
+
+**Standard method set:**
+
+| Method | Semantics | Status |
+|---|---|---|
+| `save*` | Full-replace upsert (create or replace) | Implemented |
+| `query*` | Structured multi-criterion search with pagination | Implemented |
+| `get*` | Single-record lookup by primary key | Implemented |
+| `delete*` | Delete record by primary key | Implemented |
+| `patch*` | Partial update via field mask | Deferred (see below) |
+| `bulk Save*` | Bulk full-replace upsert for large imports | Deferred (see below) |
+
+**Pagination** (`query*` methods): use `uint32 limit` + `string pageToken` in the request
+and `string nextPageToken` in the result message. An empty `nextPageToken` signals the last
+page. Do not include a `totalCount` field — obtaining it requires an expensive separate
+count query against MongoDB.
+
+**Query criteria**: use `repeated *Criterion criteria` (not `clauses`). Multiple criteria
+are combined with AND; multiple values within a single criterion are combined with OR.
+Name/alias criteria provide `exact`, `prefix`, and `contains` sub-lists (all ORed).
+`AttributesCriterion` uses an empty `values` list to mean key-only (existence) search —
+do not add a `keyOnly` flag.
+
+**`save*` full-replace warning**: comments on `Save*Request` must explicitly warn that all
+fields are replaced on update and callers must supply the complete desired state. Reference
+`patch*` as the future partial-update path.
+
+**Deferred methods** (`patch*`, `bulkSave*`): include the RPC stub and request/response
+messages in the proto even when not yet implemented, to reserve names and establish the
+pattern. Mark them clearly in both the service comment and the request message comment:
+
+```proto
+/*
+ * patchFoo()
+ *
+ * <description of intended behavior>
+ *
+ * NOT YET IMPLEMENTED — calling this method returns an error response.
+ * Planned for a future release.
+ *
+ * This method is defined now to reserve its name and message shapes as part
+ * of the standard CRUD pattern for metadata APIs in this service.
+ */
+rpc patchFoo(PatchFooRequest) returns (PatchFooResponse);
+```
+
+The service handler must return `RESULT_STATUS_ERROR` with a "not implemented" message
+for deferred methods.
+
 ## Build
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This document includes the following information:
   - [Provider API](#provider-api)
   - [PV Time-Series Data API](#pv-time-series-data-api)
   - [Ingestion Request Status API](#ingestion-request-status-api)
+  - [PV Metadata API](#pv-metadata-api)
   - [Data Set API](#data-set-api)
   - [Annotation API](#annotation-api)
 - [Data Platform API conventions](#data-platform-API-conventions)
@@ -54,11 +55,11 @@ The main objective of the Ingestion Service API is to provide a streamlined high
 
 ### Query Service API
 
-The core feature of the Query Service API is retrieval of PV time-series data over a range of time.  There are both unary and streaming query methods, with results that contain either bucketed or tabular data.  Methods are also provided for querying ingestion metadata for PVs and data providers.
+The core feature of the Query Service API is retrieval of PV time-series data over a range of time.  There are both unary and streaming query methods, with results that contain either bucketed or tabular data.  Methods are also provided for querying archive ingestion statistics for PVs and data providers.
 
 ### Annotation Service API
 
-The Annotation Service API provides tools for augmenting the PV time-series data archive with facility-specific information.  The core feature is identifying datasets, each containing blocks of data defined by a list of PVs and a range of time, and adding annotations to those datasets.  An annotation includes descriptive elements like freeform text comment, keywords, and key-value attributes, and may also include user-defined calculations that use links for tracking data provenance.  The API also includes tools for exporting datasets and calculations to common file formats including HDF5, CSV, and XLSX.  Features under development include a PV catalog, machine configuration at a point in time, and marking the disposition of individual PV samples.
+The Annotation Service API provides tools for augmenting the PV time-series data archive with facility-specific information.  The core feature is identifying datasets, each containing blocks of data defined by a list of PVs and a range of time, and adding annotations to those datasets.  An annotation includes descriptive elements like freeform text comment, keywords, and key-value attributes, and may also include user-defined calculations that use links for tracking data provenance.  The API also includes tools for exporting datasets and calculations to common file formats including HDF5, CSV, and XLSX.  A PV metadata API is provided for associating user-defined metadata (aliases, tags, attributes, description) with PVs and using that metadata to discover PVs of interest.
 
 ### Ingestion Stream Service API
 
@@ -81,36 +82,38 @@ The Data Platform API is defined in the following _proto_ files, located in this
 ## Service API Summary
 The table below gives an overview of the Data Platform API organized by service.  Links to additional details are provided for each method category.
 
-| Service          | API Methods                                                                                                                                                                                                                                                                        |
-|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Ingestion        | [Provider&nbsp;registration](#provider-registration-methods)<br>[PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Request&nbsp;Status&nbsp;query](#request-status-query-methods)<br>                |
-| Query            | [PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;metadata&nbsp;query](#provider-metadata-query-methods)<br>                                      |
-| Annotation       | [Data&nbsp;Set&nbsp;creation](#data-set-creation-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;export](#data-export-methods)<br>[Annotation&nbsp;creation](#annotation-creation-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br> |
-| Ingestion Stream | [Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>                                                                                                                                                                                                       |
+| Service          | API Methods                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Ingestion        | [Provider&nbsp;registration](#provider-registration-methods)<br>[PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Request&nbsp;Status&nbsp;query](#request-status-query-methods)<br>                                                                                                                                                                      |
+| Query            | [PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;stats&nbsp;query](#provider-stats-query-methods)<br>                                                                                                                                                                                                        |
+| Annotation       | [PV&nbsp;metadata&nbsp;save](#pv-metadata-save-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[PV&nbsp;metadata&nbsp;get](#pv-metadata-get-methods)<br>[PV&nbsp;metadata&nbsp;delete](#pv-metadata-delete-methods)<br>[Data&nbsp;Set&nbsp;save](#data-set-save-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;export](#data-export-methods)<br>[Annotation&nbsp;save](#annotation-save-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br> |
+| Ingestion Stream | [Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>                                                                                                                                                                                                                                                                                                                                                             |
 
 ---
 ## Entity API Summary
 
 The table below gives an overview of the Data Platform API organized by entity.  A brief description of each entity is provided with links to additional details about API support for that entity.
 
-| Entity   | Description | API Methods                                                                                                                                                                                                                                                                                                                    |
-|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Provider | An infrastructure component that sends correlated PV time-series data to the archive.  Might be associated with an EPICS IOC. | [Provider&nbsp;registration](#provider-registration-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;metadata&nbsp;query](#provider-metadata-query-methods)<br>                                                                                                                                    |
-| PV Time-Series Data | The core of the MLDP archive is correlated PV time-series data captured from devices in an accelerator facility. | [PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br> |
+| Entity   | Description | API Methods                                                                                                                                                                                                                                                                                                                                                                         |
+|----------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Provider | An infrastructure component that sends correlated PV time-series data to the archive.  Might be associated with an EPICS IOC. | [Provider&nbsp;registration](#provider-registration-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;stats&nbsp;query](#provider-stats-query-methods)<br>                                                                                                                                         |
+| PV Time-Series Data | The core of the MLDP archive is correlated PV time-series data captured from devices in an accelerator facility. | [PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>      |
+| PV Metadata | User-defined metadata associated with a PV, including aliases, tags, key-value attributes, and description.  Used to discover and identify PVs of interest. | [PV&nbsp;metadata&nbsp;save](#pv-metadata-save-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[PV&nbsp;metadata&nbsp;get](#pv-metadata-get-methods)<br>[PV&nbsp;metadata&nbsp;delete](#pv-metadata-delete-methods)<br>                                                                               |
 | Ingestion Request Status | Data ingestion requests are handled asynchronously to maximize performance, so the disposition of individual requests is recorded in a Request Status record. | [Request&nbsp;Status&nbsp;query](#request-status-query-methods)<br>                                                                                                                                                                                                                                                            |
-| Data Set | A Data Set identifies PV data of interest in the archive through the use of Data Blocks, each one identifying a list of PVs and range of time. | [Data&nbsp;Set&nbsp;creation](#data-set-creation-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;Set&nbsp;export](#data-set-export-methods)<br>                                                                                                                                                  |
-| Annotation | Annotations are used to annotate Data Sets in the archive with descriptive information, data associations, Calculations, and provenance tracking information. | [Annotation&nbsp;creation](#annotation-creation-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br>                                                                                                                                                                                                             |
+| Data Set | A Data Set identifies PV data of interest in the archive through the use of Data Blocks, each one identifying a list of PVs and range of time. | [Data&nbsp;Set&nbsp;save](#data-set-save-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;Set&nbsp;export](#data-set-export-methods)<br>                                                                                                                                                          |
+| Annotation | Annotations are used to annotate Data Sets in the archive with descriptive information, data associations, Calculations, and provenance tracking information. | [Annotation&nbsp;save](#annotation-save-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br>                                                                                                                                                                                                                    |
 
 
 
 ---
 ## API Use Cases and Patterns
 The Data Platform API is intended to support the following use cases and patterns:
-- Register ingestion data Providers, query Provider details and metadata.
+- Register ingestion data Providers, query Provider details and archive ingestion statistics.
 - Ingest PV time-series data, either in continuous or batch mode.
 - Subscribe to PV data and data events from the ingestion stream.
 - Monitor ingestion Request Status records for errors and other problems.
-- Query PV time-series data and metadata.
+- Query PV time-series data and archive ingestion statistics.
+- Save and query user-defined PV metadata (aliases, tags, attributes, description) to discover and identify PVs of interest.
 - Create Data Sets identifying archive data blocks of interest by PVs and time range.
 - Annotate Data Sets by adding descriptive information, linking to associated other Data Sets and Annotations, adding user-defined Calculations, and tracking data provenance.
 - Query Annotations and identify Data Sets of interest.
@@ -182,11 +185,11 @@ The response message payload is either an ExceptionalResult indicating rejection
 </tr>
 </table>
 
-### Provider Metadata Query Methods
+### Provider Stats Query Methods
 <table>
 <tr>
 <td><pre>
-rpc queryProviderMetadata(QueryProviderMetadataRequest) returns (QueryProviderMetadataResponse);
+rpc queryProviderStats(QueryProviderStatsRequest) returns (QueryProviderStatsResponse);
 </pre></td>
 </tr>
 <tr>
@@ -194,7 +197,7 @@ rpc queryProviderMetadata(QueryProviderMetadataRequest) returns (QueryProviderMe
 </tr>
 <tr>
 <td>
-The queryProviderMetadata() API method is used by clients to retrieve ingestion statistics for data Providers defined in the archive.  It accepts a single QueryProviderMetadataRequest message containing the query parameters, and returns a single QueryProviderMetadataResponse.  
+The queryProviderStats() API method is used by clients to retrieve archive ingestion statistics for data Providers defined in the archive.  It accepts a single QueryProviderStatsRequest message containing the query parameters, and returns a single QueryProviderStatsResponse.
 
 ----
 
@@ -202,7 +205,7 @@ The request message includes the unique id of a data Provider.
 
 ----
 
-The response message payload is either an ExceptionalResult indicating rejection or an error handling the request, or a MetadataResult with a ProviderMetadata entry for the Provider matching the id specified in the request.
+The response message payload is either an ExceptionalResult indicating rejection or an error handling the request, or a StatsResult with a ProviderStats entry for the Provider matching the id specified in the request.
 </td>
 </tr>
 </table>
@@ -358,7 +361,7 @@ For queryDataBidiStream(), the client sends a single QueryDataRequest message, r
 
 Except for queryDataTable(), all time-series data query methods return QueryDataResponse messages.  A QueryDataResponse contains one of two message payloads, ExceptionalResult if an error is encountered or no data is found (described above) or QueryData with the query results.
 
-A QueryData message includes a list of DataBucket messages.  Each DataBucket contains a vector of data using one of the heterogeneous column messages for a single PV, along with time expressed using a "DataTimestamps" message (described above), with either an explicit list of timestamps for the bucket data values or a SamplingClock with start time and sample period.  The DataBucket also includes a list of tags and/or a list of key/value "Attribute" pairs if those descriptive fields were specified on the ingestion request that created the bucket.
+A QueryData message includes a list of DataBucket messages.  Each DataBucket contains a vector of data using one of the heterogeneous column messages for a single PV, along with time expressed using a "DataTimestamps" message (described above), with either an explicit list of timestamps for the bucket data values or a SamplingClock with start time and sample period.  If ColumnMetadata (including provenance, tags, and/or key-value attributes) was supplied for the column at ingestion time, it is returned in the embedded column message within the DataBucket.
 
 ----
 
@@ -475,11 +478,11 @@ The service sends SubscribeDataEventResponse messages in the response stream for
 </tr>
 </table>
 
-### PV Metadata Query Methods
+### PV Stats Query Methods
 <table>
 <tr>
 <td><pre>
-rpc queryPvMetadata(QueryPvMetadataRequest) returns (QueryPvMetadataResponse);
+rpc queryPvStats(QueryPvStatsRequest) returns (QueryPvStatsResponse);
 </pre></td>
 </tr>
 <tr>
@@ -488,21 +491,19 @@ rpc queryPvMetadata(QueryPvMetadataRequest) returns (QueryPvMetadataResponse);
 <tr>
 <td>
 
-The Data Platform Query Service includes a single method, queryPvMetadata(), for querying the archive's metadata about the PVs available in the archive and ingestion statistics for those PVs.
+The queryPvStats() method queries archive ingestion statistics for PVs available in the archive.  It is a unary single request/response method that accepts a QueryPvStatsRequest and returns a QueryPvStatsResponse.
 
-It is a unary single request/response method that accepts a QueryPvMetadataRequest and returns a QueryPvMetadataResponse.
-
-
-----
-
-The QueryPvMetadataRequest message contains one of two payloads, PvNameList or PvNamePattern.  A PvNameList message specifies an explicit list of PVs to find metadata for.  A PvNamePattern specifies a regular expression pattern for matching against PV names available in the archive.
-
+For querying user-defined PV metadata (aliases, tags, attributes, description), see [PV Metadata API](#pv-metadata-api) in the Annotation Service.
 
 ----
 
-The QueryPvMetadataResponse message contains the result of a metadata query and includes one of two payloads, either an ExceptionalResult if an error is encountered or no data is found or MetadataResult with the results of the query.
+The QueryPvStatsRequest message contains one of two payloads, PvNameList or PvNamePattern.  A PvNameList message specifies an explicit list of PVs to retrieve stats for.  A PvNamePattern specifies a regular expression pattern for matching against PV names available in the archive.
 
-A MetadataResult message contains a list of PvInfo messages, one for each PV specified for the query (either explicitly in the PV name list or by matching the supplied PV name pattern).  A PvInfo message contains metadata for an individual PV in the archive, including name, timestamps for the first and last PV measurement in the archive, and stats for the most recent bucket including bucket id, data type information, data timestamps details, total number of data buckets, and sample count/period.
+----
+
+The QueryPvStatsResponse message contains one of two payloads, either an ExceptionalResult if an error is encountered or no data is found, or a StatsResult with the results of the query.
+
+A StatsResult message contains a list of PvStats messages, one for each PV matching the query.  A PvStats message contains archive ingestion statistics for an individual PV, including name, timestamps for the first and last PV measurement in the archive, and stats for the most recent bucket including bucket id, data type information, data timestamps details, total number of data buckets, and sample count/period.
 
 </td>
 </tr>
@@ -551,6 +552,155 @@ Each RequestStatus message contains details about the status of an individual in
 
 
 
+## PV Metadata API
+
+The PV Metadata API, part of the Annotation Service, provides methods for associating user-defined metadata with PVs and using that metadata to discover PVs of interest.  A PV metadata record stores the canonical PV name as its primary key, along with optional aliases (historical or alternate names), keyword tags, key-value attributes, and a free-text description.  Records also include audit timestamps (`createdTime`, `updatedTime`) and an optional `modifiedBy` field identifying the last writer.
+
+No pre-registration of PVs is required — metadata records can be created independently of whether data has been ingested for a PV.
+
+For querying archive ingestion statistics (first/last data timestamp, bucket counts, data types), see [PV Stats Query Methods](#pv-stats-query-methods) in the Query Service.
+
+### PV Metadata Save Methods
+<table>
+<tr>
+<td><pre>
+rpc savePvMetadata(SavePvMetadataRequest) returns (SavePvMetadataResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+The savePvMetadata() method creates or replaces the metadata record for a PV.  It uses full-replace upsert semantics: if no record exists for the PV name, a new record is created; if a record already exists, all fields are replaced with the contents of the request.
+
+**Warning:** Fields omitted from the request are not preserved on update — callers must supply the complete desired state on every save.  Use patchPvMetadata() (future) for partial updates.
+
+----
+
+A SavePvMetadataRequest includes the required canonical PV name and optional fields: aliases, tags, attributes, modifiedBy, and description.  Data normalization rules applied by the service: tags and aliases are normalized to a lowercase unique set; attribute keys must be unique within the request.
+
+----
+
+The response payload is an ExceptionalResult if the request is rejected or an error is encountered, otherwise a SavePvMetadataResult containing the canonical PV name of the created or updated record.
+
+</td>
+</tr>
+</table>
+
+### PV Metadata Query Methods
+<table>
+<tr>
+<td><pre>
+rpc queryPvMetadata(QueryPvMetadataRequest) returns (QueryPvMetadataResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+The queryPvMetadata() method searches PV metadata records using structured criteria and returns a paginated result.
+
+----
+
+A QueryPvMetadataRequest contains a list of QueryPvMetadataCriterion entries and optional pagination parameters (limit, pageToken).  Multiple criteria are combined with logical AND; values within a single criterion are combined with logical OR.  Criterion types include:
+
+- **PvNameCriterion** — match by canonical PV name using exact, prefix, and/or contains sub-lists (all ORed together).
+- **AliasesCriterion** — match by alias using the same exact/prefix/contains sub-lists.
+- **TagsCriterion** — match records that have any of the specified tags.
+- **AttributesCriterion** — match by attribute key and optional value(s); an empty values list matches any record that has the key regardless of value (key-only / existence search).
+
+----
+
+The response payload is an ExceptionalResult if the request is rejected or an error is encountered, otherwise a PvMetadataResult containing a list of PvMetadata records and a nextPageToken for retrieving subsequent pages.  An empty nextPageToken indicates the last page.  An empty result set is returned as a PvMetadataResult with an empty list, not an ExceptionalResult.
+
+</td>
+</tr>
+</table>
+
+### PV Metadata Get Methods
+<table>
+<tr>
+<td><pre>
+rpc getPvMetadata(GetPvMetadataRequest) returns (GetPvMetadataResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+The getPvMetadata() method retrieves a single PV metadata record by canonical PV name or alias.  It is a convenience method for the common single-record lookup case, as an alternative to using queryPvMetadata() with a single exact PvNameCriterion.
+
+----
+
+A GetPvMetadataRequest contains the PV name or alias to look up.  The service first searches by canonical PV name; if no match is found it searches aliases.
+
+----
+
+The response payload is an ExceptionalResult if the request is rejected, an error is encountered, or no matching record is found, otherwise the matching PvMetadata record.
+
+</td>
+</tr>
+</table>
+
+### PV Metadata Delete Methods
+<table>
+<tr>
+<td><pre>
+rpc deletePvMetadata(DeletePvMetadataRequest) returns (DeletePvMetadataResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+The deletePvMetadata() method deletes the metadata record for the specified canonical PV name.
+
+----
+
+A DeletePvMetadataRequest contains the canonical PV name of the record to delete.  Aliases are not accepted as delete keys.
+
+----
+
+The response payload is an ExceptionalResult if the request is rejected, an error is encountered, or no record exists for the specified PV name, otherwise a DeletePvMetadataResult containing the canonical PV name of the deleted record.
+
+</td>
+</tr>
+</table>
+
+### PV Metadata Placeholder Methods
+
+Two additional PV metadata methods are defined in the proto but not yet implemented.  Calling either method returns an error response.  They are defined now to reserve their names and establish the standard CRUD pattern for metadata APIs in this service.
+
+<table>
+<tr>
+<td><pre>
+rpc patchPvMetadata(PatchPvMetadataRequest) returns (PatchPvMetadataResponse);
+rpc bulkSavePvMetadata(BulkSavePvMetadataRequest) returns (BulkSavePvMetadataResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+**patchPvMetadata()** will provide partial-update semantics, allowing individual fields to be updated without replacing the entire record.  Field mask design is deferred to the release that implements this method.
+
+**bulkSavePvMetadata()** will accept a list of SavePvMetadataRequest messages and apply the same full-replace upsert semantics as savePvMetadata() to each record in a single request.  Intended for large initial imports or bulk synchronization use cases.
+
+</td>
+</tr>
+</table>
+
+
 ## Data Set API
 
 When designing the Data Platform's Annotation Service, we found we needed a mechanism for specifying a collection of data in the archive as the subject of an annotation.  We decided to add the notion of a Data Set consisting of a list of Data Blocks, where each Data Block specifies a list of PV names and a time range.
@@ -563,11 +713,11 @@ The file ___annotation.proto___ defines the messages DataSet and DataBlock for u
 
 The API includes methods for creating, querying, and exporting Data Sets.  Each is described in more detail below.
 
-### Data Set Creation Methods
+### Data Set Save Methods
 <table>
 <tr>
 <td><pre>
-rpc createDataSet(CreateDataSetRequest) returns (CreateDataSetResponse);
+rpc saveDataSet(SaveDataSetRequest) returns (SaveDataSetResponse);
 </pre></td>
 </tr>
 <tr>
@@ -576,17 +726,17 @@ rpc createDataSet(CreateDataSetRequest) returns (CreateDataSetResponse);
 <tr>
 <td>
 
-createDataSet() is a unary single request/response method for creating a dataset.  It accepts a CreateDataSetRequest message and returns a CreateDataSetResponse.
+saveDataSet() is a unary single request/response method for creating or updating a dataset.  It accepts a SaveDataSetRequest message and returns a SaveDataSetResponse.
 
 ----
 
-A CreateDataSetRequest message contains a DataSet message with details of the dataset to be created, e.g., its list of DataBlock messages.  Each DataBlock message specifies a list of PVs and a range of time to identify a region of interest in the archive.
+A SaveDataSetRequest message contains a DataSet message with details of the dataset to be created or updated, e.g., its list of DataBlock messages.  Each DataBlock message specifies a list of PVs and a range of time to identify a region of interest in the archive.  If the DataSet's id field is populated, the corresponding existing DataSet is updated; otherwise a new DataSet is created.
 
 ----
 
-A CreateDataSetResponse message contains one of two payloads, an ExceptionalResult message if a rejection or error was encountered creating the dataset, or a CreateDataSetResult.
+A SaveDataSetResponse message contains one of two payloads, an ExceptionalResult message if a rejection or error was encountered, or a SaveDataSetResult.
 
-A CreateDataSetResult message simply contains the unique identifier assigned to the new dataset if it was created successfully.
+A SaveDataSetResult message contains the unique identifier of the new or updated dataset.
 
 </td>
 </tr>
@@ -710,11 +860,11 @@ The Calculations object includes a list of CalculationsDataFrames.  Each Calcula
 
 It might be helpful to use the analogy of an Excel workbook.  The Calculations object is the workbook, and each CalculationDataFrame is a worksheet in that workbook that contains a column of timestamps and columns of calculated data with a value for each timestamp.
 
-### Annotation Creation Methods
+### Annotation Save Methods
 <table>
 <tr>
 <td><pre>
-rpc createAnnotation(CreateAnnotationRequest) returns (CreateAnnotationResponse);
+rpc saveAnnotation(SaveAnnotationRequest) returns (SaveAnnotationResponse);
 </pre></td>
 </tr>
 <tr>
@@ -723,17 +873,17 @@ rpc createAnnotation(CreateAnnotationRequest) returns (CreateAnnotationResponse)
 <tr>
 <td>
 
-The method createAnnotation() creates an Annotation for the specified list of associated dataset(s).  It accepts a CreateAnnotationRequest message and returns a CreateAnnotationResponse message.
+The method saveAnnotation() creates or updates an Annotation for the specified list of associated dataset(s).  It accepts a SaveAnnotationRequest message and returns a SaveAnnotationResponse message.
 
 ----
 
-A CreateAnnotationRequest includes fields for the required and optional Annotation fields described above.
+A SaveAnnotationRequest includes fields for the required and optional Annotation fields described above.  If the optional id field is populated, the corresponding existing Annotation is updated; otherwise a new Annotation is created.
 
 ----
 
-A CreateAnnotationResponse message is used to return the result of the createAnnotation() method.  It includes one of two payloads, either an ExceptionalResult (described above) if an error is encountered creating the Annotation, or a CreateAnnotationResult if the operation is successful.
+A SaveAnnotationResponse message includes one of two payloads, either an ExceptionalResult if an error is encountered, or a SaveAnnotationResult if the operation is successful.
 
-A CreateAnnotationResult message simply contains the unique identifier assigned to the annotation.
+A SaveAnnotationResult message contains the unique identifier of the new or updated annotation.
 
 </td>
 </tr>

--- a/src/main/proto/annotation.proto
+++ b/src/main/proto/annotation.proto
@@ -72,6 +72,87 @@ service DpAnnotationService {
    * details about the exported file including the path and optional (if configured) URL for accessing the file.
    */
   rpc exportData(ExportDataRequest) returns (ExportDataResponse);
+
+  /*
+   * savePvMetadata()
+   *
+   * Create or replace the metadata record for the specified PV.
+   *
+   * Full replace (upsert) semantics: if a record does not exist it is created;
+   * if a record already exists, ALL fields (aliases, tags, attributes,
+   * description, modifiedBy) are replaced with the request contents.
+   * Callers must supply the complete desired state on every call — fields
+   * omitted from the request are not preserved.  Use patchPvMetadata()
+   * (future) for partial updates.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * successful handling of the request.
+   */
+  rpc savePvMetadata(SavePvMetadataRequest) returns (SavePvMetadataResponse);
+
+  /*
+   * queryPvMetadata()
+   *
+   * Query PV metadata records using structured search criteria.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a PvMetadataResult containing the matching records and pagination token.
+   */
+  rpc queryPvMetadata(QueryPvMetadataRequest) returns (QueryPvMetadataResponse);
+
+  /*
+   * getPvMetadata()
+   *
+   * Retrieve a single PV metadata record by canonical PV name or alias.
+   * Provided as a convenience over queryPvMetadata() for the common
+   * single-record lookup case.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a GetPvMetadataResponse containing the matching record.  If no record
+   * is found for the specified name or alias, an ExceptionalResult is returned.
+   */
+  rpc getPvMetadata(GetPvMetadataRequest) returns (GetPvMetadataResponse);
+
+  /*
+   * patchPvMetadata()
+   *
+   * Partial update of an existing PV metadata record.  Allows individual
+   * fields (aliases, tags, attributes, description, modifiedBy) to be updated
+   * without replacing the entire record, unlike the full-replace semantics
+   * of savePvMetadata().
+   *
+   * NOT YET IMPLEMENTED — calling this method returns an error response.
+   * Planned for a future release.  Field mask design is deferred.
+   *
+   * This method is defined now to reserve its name and message shapes as part
+   * of the standard CRUD pattern for metadata APIs in this service.
+   */
+  rpc patchPvMetadata(PatchPvMetadataRequest) returns (PatchPvMetadataResponse);
+
+  /*
+   * deletePvMetadata()
+   *
+   * Delete the metadata record for the specified canonical PV name.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a DeletePvMetadataResult confirming the name of the deleted record.
+   */
+  rpc deletePvMetadata(DeletePvMetadataRequest) returns (DeletePvMetadataResponse);
+
+  /*
+   * bulkSavePvMetadata()
+   *
+   * Bulk create or replace multiple PV metadata records in a single request.
+   * Each record uses the same full-replace upsert semantics as savePvMetadata().
+   * Intended for large initial imports or bulk synchronization use cases.
+   *
+   * NOT YET IMPLEMENTED — calling this method returns an error response.
+   * Planned for a future release.
+   *
+   * This method is defined now to reserve its name and message shapes as part
+   * of the standard bulk-write pattern for metadata APIs in this service.
+   */
+  rpc bulkSavePvMetadata(BulkSavePvMetadataRequest) returns (BulkSavePvMetadataResponse);
 }
 
 
@@ -498,5 +579,363 @@ message ExportDataResponse {
   message ExportDataResult {
     string filePath = 1; // Specifies full path to export output file.
     string fileUrl = 2; // (If configured to generate URLs) Specifies URL for accessing file via web server.
+  }
+}
+
+
+//
+// ------------------- PV Metadata Save Request/Response ---------------------------
+//
+
+/*
+ * SavePvMetadataRequest
+ *
+ * Encapsulates the details for creating or replacing the metadata record for
+ * the specified PV.
+ *
+ * Full replace (upsert) semantics:
+ *   - If no record exists for pvName, a new record is created.
+ *   - If a record already exists, aliases / tags / attributes / description /
+ *     modifiedBy are ALL replaced with the values in this request.
+ *
+ * WARNING: Fields omitted from the request are NOT preserved on update.
+ * Callers must supply the complete desired state on every save.
+ * patchPvMetadata() (future placeholder) will provide partial-update semantics.
+ *
+ * Data normalization rules applied by the service:
+ *   - tags are normalized to a lowercase unique set.
+ *   - attribute keys (Attribute.name) must be unique within the request;
+ *     duplicate keys are rejected.
+ */
+message SavePvMetadataRequest {
+
+  string pvName = 1; // required canonical PV name
+  repeated string aliases = 2; // optional historical / alternate names
+  repeated string tags = 3; // optional keyword tags
+  repeated dp.service.common.Attribute attributes = 4; // optional key/value attribute pairs
+  string modifiedBy = 5; // optional actor / user / service identity
+  string description = 6; // optional free-text description
+}
+
+/*
+ * SavePvMetadataResponse
+ *
+ * Contains the response to a savePvMetadata() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a SavePvMetadataResult.
+ */
+message SavePvMetadataResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    SavePvMetadataResult savePvMetadataResult = 11;
+  }
+
+  /*
+   * SavePvMetadataResult
+   *
+   * Contains the result of a successful savePvMetadata() request.
+   */
+  message SavePvMetadataResult {
+    string pvName = 1; // canonical PV name of the created or updated record
+  }
+}
+
+
+//
+// ------------------- PV Metadata Query ---------------------------
+//
+
+/*
+ * QueryPvMetadataRequest
+ *
+ * Contains parameters for a PV metadata query using structured search criteria.
+ *
+ * Combining semantics:
+ *   - Multiple criteria in the top-level list are combined with logical AND:
+ *     a record must satisfy ALL criteria to be returned.
+ *   - Within a single criterion, all match values / sub-lists are combined
+ *     with logical OR: a record satisfies the criterion if it matches ANY
+ *     supplied value.
+ *   - Within PvNameCriterion and AliasesCriterion, the exact / prefix /
+ *     contains sub-lists are each ORed internally and then ORed together:
+ *     a name matches if it satisfies any value from any sub-list.
+ *
+ * Pagination:
+ *   - limit specifies the maximum number of records to return per response.
+ *   - pageToken is omitted on the first request; subsequent requests supply
+ *     the nextPageToken returned in the previous response.
+ *   - An empty nextPageToken in the response indicates no further pages.
+ */
+message QueryPvMetadataRequest {
+
+  repeated QueryPvMetadataCriterion criteria = 1;
+
+  uint32 limit = 2;
+  string pageToken = 3;
+
+  /*
+   * QueryPvMetadataCriterion
+   *
+   * A single search criterion.  Exactly one criterion must be set.
+   */
+  message QueryPvMetadataCriterion {
+
+    oneof criterion {
+      PvNameCriterion pvNameCriterion = 10;
+      TagsCriterion tagsCriterion = 11;
+      AttributesCriterion attributesCriterion = 12;
+      AliasesCriterion aliasesCriterion = 13;
+    }
+
+    /*
+     * PvNameCriterion
+     *
+     * Match records by canonical PV name.  Values across all three sub-lists
+     * are ORed: a name matches if it satisfies any supplied value from any
+     * sub-list.
+     */
+    message PvNameCriterion {
+      repeated string exact = 1;    // exact string match
+      repeated string prefix = 2;   // prefix match
+      repeated string contains = 3; // substring match
+    }
+
+    /*
+     * TagsCriterion
+     *
+     * Match records that have any of the specified tags.  Multiple tags within
+     * a single TagsCriterion are ORed; use separate TagsCriterion entries in
+     * the outer criteria list (ANDed) to require multiple tags simultaneously.
+     */
+    message TagsCriterion {
+      repeated string tags = 1;
+    }
+
+    /*
+     * AttributesCriterion
+     *
+     * Match records by attribute key and optional value(s).
+     * key (maps to Attribute.name) is required.
+     * values is optional: if non-empty, the record must have the key with one
+     * of the specified values (OR); if empty, any record possessing the key
+     * matches regardless of its value (key-only / existence search).
+     */
+    message AttributesCriterion {
+      string key = 1;             // required; matches Attribute.name
+      repeated string values = 2; // optional; empty list = key-only search
+    }
+
+    /*
+     * AliasesCriterion
+     *
+     * Match records by alias.  Mirrors PvNameCriterion: values across all
+     * three sub-lists are ORed.
+     */
+    message AliasesCriterion {
+      repeated string exact = 1;    // exact string match
+      repeated string prefix = 2;   // prefix match
+      repeated string contains = 3; // substring match
+    }
+  }
+}
+
+/*
+ * QueryPvMetadataResponse
+ *
+ * Contains the results of a queryPvMetadata() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a PvMetadataResult with the matching records.
+ *
+ * An empty query result is returned as a PvMetadataResult with an empty
+ * pvMetadata list (not an ExceptionalResult).
+ */
+message QueryPvMetadataResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    PvMetadataResult pvMetadataResult = 11;
+  }
+
+  /*
+   * PvMetadataResult
+   *
+   * Contains a page of PvMetadata records matching the query criteria.
+   *
+   * nextPageToken is non-empty when additional pages are available; supply it
+   * as pageToken in the next request to retrieve the following page.
+   * An empty nextPageToken indicates the last page.
+   */
+  message PvMetadataResult {
+    repeated dp.service.common.PvMetadata pvMetadata = 1;
+    string nextPageToken = 2;
+  }
+}
+
+
+//
+// ------------------- PV Metadata Get / Patch / Delete / Bulk Save ---------------------------
+//
+
+/*
+ * GetPvMetadataRequest
+ *
+ * Retrieve a single PV metadata record by canonical PV name or alias.
+ */
+message GetPvMetadataRequest {
+  string pvName = 1; // canonical PV name or alias
+}
+
+/*
+ * GetPvMetadataResponse
+ *
+ * Contains the result of a getPvMetadata() request.  Payload is an
+ * ExceptionalResult if the request is rejected, an error is encountered, or
+ * no record is found, otherwise contains the matching PvMetadata record.
+ */
+message GetPvMetadataResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    dp.service.common.PvMetadata pvMetadata = 11;
+  }
+}
+
+/*
+ * PatchPvMetadataRequest
+ *
+ * Partial update of an existing PV metadata record.
+ *
+ * NOT YET IMPLEMENTED.  The patch fields and field mask mechanism are deferred
+ * to the release that implements patchPvMetadata().  This message is defined
+ * now to reserve the name and establish the pattern.
+ */
+message PatchPvMetadataRequest {
+  string pvName = 1; // required canonical PV name
+}
+
+/*
+ * PatchPvMetadataResponse
+ *
+ * Contains the result of a patchPvMetadata() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a PatchPvMetadataResult.
+ */
+message PatchPvMetadataResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    PatchPvMetadataResult patchPvMetadataResult = 11;
+  }
+
+  /*
+   * PatchPvMetadataResult
+   *
+   * Contains the result of a successful patchPvMetadata() request.
+   */
+  message PatchPvMetadataResult {
+    string pvName = 1; // canonical PV name of the updated record
+  }
+}
+
+/*
+ * DeletePvMetadataRequest
+ *
+ * Delete the metadata record for the specified canonical PV name.
+ */
+message DeletePvMetadataRequest {
+  string pvName = 1; // required canonical PV name
+}
+
+/*
+ * DeletePvMetadataResponse
+ *
+ * Contains the result of a deletePvMetadata() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a DeletePvMetadataResult.
+ */
+message DeletePvMetadataResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    DeletePvMetadataResult deletePvMetadataResult = 11;
+  }
+
+  /*
+   * DeletePvMetadataResult
+   *
+   * Contains the result of a successful deletePvMetadata() request.
+   */
+  message DeletePvMetadataResult {
+    string pvName = 1; // canonical PV name of the deleted record
+  }
+}
+
+/*
+ * BulkSavePvMetadataRequest
+ *
+ * Bulk create or replace multiple PV metadata records in a single request.
+ * Each record uses the same full-replace upsert semantics as savePvMetadata().
+ * Intended for large initial imports or bulk synchronization use cases.
+ *
+ * NOT YET IMPLEMENTED.  This message is defined now to reserve the name and
+ * establish the pattern for bulk-write operations in this service.
+ */
+message BulkSavePvMetadataRequest {
+  repeated SavePvMetadataRequest requests = 1;
+}
+
+/*
+ * BulkSavePvMetadataResponse
+ *
+ * Contains the result of a bulkSavePvMetadata() request.  Payload is an
+ * ExceptionalResult if the entire request is rejected (e.g. validation failure
+ * before any records are processed), otherwise contains a
+ * BulkSavePvMetadataResult reporting the count of successfully saved records
+ * and per-item details for any failures.
+ *
+ * A response with BulkSavePvMetadataResult and a non-empty errors list
+ * indicates a partial failure: some records were saved and some were not.
+ */
+message BulkSavePvMetadataResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    BulkSavePvMetadataResult bulkSavePvMetadataResult = 11;
+  }
+
+  /*
+   * BulkSavePvMetadataResult
+   *
+   * savedCount is the number of records successfully saved.
+   * errors contains one entry per failed record; an empty list means all
+   * records were saved successfully.
+   */
+  message BulkSavePvMetadataResult {
+
+    uint64 savedCount = 1;
+    repeated BulkSaveError errors = 2;
+
+    /*
+     * BulkSaveError
+     *
+     * Describes a failure for a single record within a bulk save request.
+     */
+    message BulkSaveError {
+      string pvName = 1;
+      dp.service.common.ExceptionalResult exceptionalResult = 2;
+    }
   }
 }

--- a/src/main/proto/annotation.proto
+++ b/src/main/proto/annotation.proto
@@ -787,7 +787,7 @@ message QueryPvMetadataResponse {
  * Retrieve a single PV metadata record by canonical PV name or alias.
  */
 message GetPvMetadataRequest {
-  string pvName = 1; // canonical PV name or alias
+  string pvNameOrAlias = 1; // canonical PV name or alias
 }
 
 /*

--- a/src/main/proto/annotation.proto
+++ b/src/main/proto/annotation.proto
@@ -132,7 +132,7 @@ service DpAnnotationService {
   /*
    * deletePvMetadata()
    *
-   * Delete the metadata record for the specified canonical PV name.
+   * Delete the metadata record for the specified canonical PV name or alias.
    *
    * The response may indicate rejection, an error handling the request, or
    * a DeletePvMetadataResult confirming the name of the deleted record.
@@ -662,6 +662,8 @@ message SavePvMetadataResponse {
  *   - Within PvNameCriterion and AliasesCriterion, the exact / prefix /
  *     contains sub-lists are each ORed internally and then ORed together:
  *     a name matches if it satisfies any value from any sub-list.
+ *   - An empty criteria list is rejected with an ExceptionalResult; at least
+ *     one criterion is required.
  *
  * Pagination:
  *   - limit specifies the maximum number of records to return per response.
@@ -711,7 +713,7 @@ message QueryPvMetadataRequest {
      * the outer criteria list (ANDed) to require multiple tags simultaneously.
      */
     message TagsCriterion {
-      repeated string tags = 1;
+      repeated string values = 1;
     }
 
     /*
@@ -795,7 +797,8 @@ message GetPvMetadataRequest {
  *
  * Contains the result of a getPvMetadata() request.  Payload is an
  * ExceptionalResult if the request is rejected, an error is encountered, or
- * no record is found, otherwise contains the matching PvMetadata record.
+ * no record is found, otherwise contains a GetPvMetadataResult with the
+ * matching PvMetadata record.
  */
 message GetPvMetadataResponse {
 
@@ -803,7 +806,16 @@ message GetPvMetadataResponse {
 
   oneof result {
     dp.service.common.ExceptionalResult exceptionalResult = 10;
-    dp.service.common.PvMetadata pvMetadata = 11;
+    GetPvMetadataResult getPvMetadataResult = 11;
+  }
+
+  /*
+   * GetPvMetadataResult
+   *
+   * Contains the result of a successful getPvMetadata() request.
+   */
+  message GetPvMetadataResult {
+    dp.service.common.PvMetadata pvMetadata = 1; // the matching PvMetadata record
   }
 }
 
@@ -849,10 +861,10 @@ message PatchPvMetadataResponse {
 /*
  * DeletePvMetadataRequest
  *
- * Delete the metadata record for the specified canonical PV name.
+ * Delete the metadata record for the specified canonical PV name or alias.
  */
 message DeletePvMetadataRequest {
-  string pvName = 1; // required canonical PV name
+  string pvNameOrAlias = 1; // required canonical PV name or alias
 }
 
 /*
@@ -925,7 +937,7 @@ message BulkSavePvMetadataResponse {
    */
   message BulkSavePvMetadataResult {
 
-    uint64 savedCount = 1;
+    uint32 savedCount = 1;
     repeated BulkSaveError errors = 2;
 
     /*

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -51,6 +51,35 @@ message ColumnMetadata {
   repeated Attribute attributes = 3;
 }
 
+/*
+ * PvMetadata
+ *
+ * Canonical metadata record for a process variable (PV).  PV name is the
+ * primary identifier — no pre-registration of PVs is required before
+ * ingestion.
+ *
+ * Placed in common.proto so it can be referenced by any service (annotation,
+ * query, etc.) without introducing cross-service import cycles.
+ *
+ * createdTime / updatedTime are included because they are often useful to API
+ * consumers for synchronization, auditing, cache invalidation, operational
+ * visibility, and UI display.
+ *
+ * modifiedBy is an unvalidated free-form string identifying the actor (user,
+ * service, or system) that performed the most recent save.  It reflects only
+ * the last writer; no history is maintained.
+ */
+message PvMetadata {
+  string pvName = 1; // canonical PV name
+  repeated string aliases = 2; // optional historical / alternate names
+  repeated string tags = 3; // optional keyword tags (normalized to lowercase unique set)
+  repeated Attribute attributes = 4; // optional key/value attribute pairs
+  Timestamp createdTime = 5; // time the record was first created
+  Timestamp updatedTime = 6; // time the record was most recently saved
+  string modifiedBy = 7; // optional actor / user / service identity for last save
+  string description = 8; // optional free-text description
+}
+
 //
 // ------------------- Time Definitions ---------------------------
 //

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -20,7 +20,7 @@ import "common.proto";
 /*
  * The Query Service Interface
  *
- * Defines RPC operations for data and metadata queries.
+ * Defines RPC operations for data and stats queries.
  */
 service DpQueryService {
 
@@ -77,14 +77,20 @@ service DpQueryService {
   rpc queryTable(QueryTableRequest) returns (QueryTableResponse);
 
   /*
-   * queryPvMetadata(): Unary (non-streaming) metadata query.
+   * queryPvStats(): Unary (non-streaming) PV archive statistics query.
    *
-   * This RPC is used by clients to learn about data sources (PVs/columns) available in the archive.  Client sends
-   * a single QueryPvMetadataRequest with the query parameters, and receives a single QueryPvMetadataResponse
-   * with the query results. The response may indicate rejection, error in handling, no data matching query, or
-   * otherwise contains the data matching the query specification.
+   * (Renamed from queryPvMetadata() — returns archive ingestion statistics,
+   * not user-defined PV metadata.  See DpAnnotationService.queryPvMetadata()
+   * for user-defined metadata queries.)
+   *
+   * This RPC is used by clients to learn about data sources (PVs/columns)
+   * available in the archive.  Client sends a single QueryPvStatsRequest
+   * with the query parameters, and receives a single QueryPvStatsResponse
+   * with the query results.  The response may indicate rejection, error in
+   * handling, no data matching query, or otherwise contains the archive
+   * statistics matching the query specification.
    */
-  rpc queryPvMetadata(QueryPvMetadataRequest) returns (QueryPvMetadataResponse);
+  rpc queryPvStats(QueryPvStatsRequest) returns (QueryPvStatsResponse);
 
   /*
    * queryProviders(): Unary Providers query.
@@ -97,14 +103,19 @@ service DpQueryService {
   rpc queryProviders(QueryProvidersRequest) returns (QueryProvidersResponse);
 
   /*
-   * queryProviderMetadata(): Unary Provider metadata query.
+   * queryProviderStats(): Unary Provider archive statistics query.
    *
-   * This rpc is used by clients to retrieve ingestion statistics for data Providers defined in the archive.
-   * It accepts a single "QueryProviderMetadataRequest" message containing the query parameters, and returns a single
-   * "QueryProviderMetadataResponse".  The response may indicate an exceptional result such as rejection or error in
-   * handling the request, otherwise it contains ingestion metadata for the specified data provider.
+   * (Renamed from queryProviderMetadata() — returns archive ingestion
+   * statistics, not user-defined provider metadata.)
+   *
+   * This RPC is used by clients to retrieve ingestion statistics for data
+   * Providers defined in the archive.  It accepts a single
+   * QueryProviderStatsRequest containing the query parameters and returns a
+   * single QueryProviderStatsResponse.  The response may indicate an
+   * exceptional result such as rejection or error in handling the request,
+   * otherwise it contains ingestion statistics for the specified data provider.
    */
-  rpc queryProviderMetadata(QueryProviderMetadataRequest) returns (QueryProviderMetadataResponse);
+  rpc queryProviderStats(QueryProviderStatsRequest) returns (QueryProviderStatsResponse);
 
 }
 
@@ -289,18 +300,18 @@ message QueryTableResponse {
 
 
 //
-// ------------------- Metadata Query ---------------------------
+// ------------------- Stats Query ---------------------------
 //
 
 /*
- * QueryPvMetadataRequest
+ * QueryPvStatsRequest
  *
- * Describes the parameters for querying metadata for PVs managed in the archive.
+ * Describes the parameters for querying stats for PVs managed in the archive.
  *
  * A request may contain one of two payloads, either a PvNameList with an explicit list of
  * column/PV names, or a PvNamePattern with a regular expression pattern used to match against column/PV names.
  */
-message QueryPvMetadataRequest {
+message QueryPvStatsRequest {
 
   // pvNameSpec: Contains either a list of column/PV names, or a single regex pattern string.
   oneof pvNameSpec {
@@ -311,32 +322,32 @@ message QueryPvMetadataRequest {
 }
 
 /*
- * QueryPvMetadataResponse
+ * QueryPvStatsResponse
  *
- * Contains results from a PV metadata query. Payload is an ExceptionalResult if a rejection, error, or empty query
- * result is encountered, otherwise is a MetadataResult containing results of query.
+ * Contains results from a PV stats query. Payload is an ExceptionalResult if a rejection, error, or empty query
+ * result is encountered, otherwise is a StatsResult containing results of query.
  */
-message QueryPvMetadataResponse {
+message QueryPvStatsResponse {
 
   dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
 
   // result: Response contains either an ExceptionalResult indicating a problem handling the request,
-  // or MetadataResult with query result.
+  // or StatsResult with query result.
   oneof result {
     dp.service.common.ExceptionalResult exceptionalResult = 10;
-    MetadataResult metadataResult = 11;
+    StatsResult statsResult = 11;
   }
 
   /*
-   * MetadataResult
+   * StatsResult
    *
-   * Contains a list of PvInfo metadata objects, one for each column/PV name matching the query specification.
+   * Contains a list of PvStats objects, one for each column/PV name matching the query specification.
    */
-  message MetadataResult {
+  message StatsResult {
 
-    repeated PvInfo pvInfos = 1; // List of metadata objects matching query specificiation.
+    repeated PvStats pvStats = 1; // List of stats objects matching query specificiation.
 
-    message PvInfo {
+    message PvStats {
       string pvName = 1; // Name of PV.
       string lastBucketId = 2; // Database identifier for PV's most recent bucket.
       string lastBucketDataType = 3; // Data type name of PV's most recent bucket.
@@ -354,11 +365,11 @@ message QueryPvMetadataResponse {
 }
 
 message PvNameList {
-  repeated string pvNames = 1; // Specifies list of column/PV names to match and return metadata for.
+  repeated string pvNames = 1; // Specifies list of column/PV names to match and return stats for.
 }
 
 message PvNamePattern {
-  string pattern = 1; // Specifies regex pattern to use for matching column/PV names to return metadata for.
+  string pattern = 1; // Specifies regex pattern to use for matching column/PV names to return stats for.
 }
 
 
@@ -442,7 +453,7 @@ message QueryProvidersResponse {
    */
   message ProvidersResult {
 
-    repeated ProviderInfo providerInfos = 1; // List of metadata objects matching query specificiation.
+    repeated ProviderInfo providerInfos = 1; // List of stats objects matching query specification.
 
     message ProviderInfo {
       string id = 1; // Provider unique id.
@@ -450,59 +461,59 @@ message QueryProvidersResponse {
       string	description = 3; // Provider description.
       repeated string tags = 4; // List of tags.
       repeated dp.service.common.Attribute attributes = 5; // List of key/value attributes.
-      ProviderMetadata providerMetadata = 6; // Ingestion stats for this provider.
+      ProviderStats providerStats = 6; // Ingestion stats for this provider.
     }
   }
 }
 
 
 //
-// ------------------- Provider Metadata Query ---------------------------
+// ------------------- Provider Stats Query ---------------------------
 //
 
 /*
- * QueryProviderMetadataRequest
+ * QueryProviderStatsRequest
  *
- * Encapsulates the single parameter for a queryProviderMetadata() request, the unique id of a data Provider.
+ * Encapsulates the single parameter for a queryProviderStats() request, the unique id of a data Provider.
  */
-message QueryProviderMetadataRequest {
+message QueryProviderStatsRequest {
   string providerId = 1;
 }
 
 /*
- * QueryProviderMetadataResponse
+ * QueryProviderStatsResponse
  *
- * Contains results from a queryProviderMetadata() API method request.  Message payload is either an
- * ExceptionalResult indicating rejection or an error handling the request, or a MetadataResult with a
- * ProviderMetadata entry for the Provider matching the id specified in the request.
+ * Contains results from a queryProviderStats() API method request.  Message payload is either an
+ * ExceptionalResult indicating rejection or an error handling the request, or a StatsResult with a
+ * ProviderStats entry for the Provider matching the id specified in the request.
  */
-message QueryProviderMetadataResponse {
+message QueryProviderStatsResponse {
 
   dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
 
   // result: Response contains either an ExceptionalResult indicating a problem handling the request,
-  // or MetadataResult with query result.
+  // or StatsResult with query result.
   oneof result {
     dp.service.common.ExceptionalResult exceptionalResult = 10;
-    MetadataResult metadataResult = 11;
+    StatsResult statsResult = 11;
   }
 
   /*
-   * Metadata Query Result Content.
+   * Stats Query Result Content.
    *
-   * Contains a list of ProviderInfo metadata objects, one for each provider matching the query specification.
+   * Contains a list of ProviderStats objects, one for each provider matching the query specification.
    */
-  message MetadataResult {
-    repeated ProviderMetadata providerMetadatas = 1; // List of metadata objects matching query specificiation.
+  message StatsResult {
+    repeated ProviderStats providerStats = 1; // List of stats objects matching query specificiation.
   }
 }
 
 /*
- * ProviderMetadata
+ * ProviderStats
  *
- * Contains metadata for a registered provider with data ingestion stats for data buckets associated with the provider.
+ * Contains stats for a registered provider with data ingestion stats for data buckets associated with the provider.
  */
-message ProviderMetadata {
+message ProviderStats {
   string id = 1; // Provider id.
   repeated string pvNames = 2; // List of PV names with buckets using provider.
   dp.service.common.Timestamp firstBucketTime = 3; // Timstamp of first bucket using provider.

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -345,7 +345,7 @@ message QueryPvStatsResponse {
    */
   message StatsResult {
 
-    repeated PvStats pvStats = 1; // List of stats objects matching query specificiation.
+    repeated PvStats pvStats = 1; // List of stats objects matching query specification.
 
     message PvStats {
       string pvName = 1; // Name of PV.
@@ -453,7 +453,7 @@ message QueryProvidersResponse {
    */
   message ProvidersResult {
 
-    repeated ProviderInfo providerInfos = 1; // List of stats objects matching query specification.
+    repeated ProviderInfo providerInfos = 1; // List of ProviderInfo objects matching query specification.
 
     message ProviderInfo {
       string id = 1; // Provider unique id.
@@ -504,7 +504,7 @@ message QueryProviderStatsResponse {
    * Contains a list of ProviderStats objects, one for each provider matching the query specification.
    */
   message StatsResult {
-    repeated ProviderStats providerStats = 1; // List of stats objects matching query specificiation.
+    repeated ProviderStats providerStats = 1; // List of stats objects matching query specification.
   }
 }
 
@@ -516,7 +516,7 @@ message QueryProviderStatsResponse {
 message ProviderStats {
   string id = 1; // Provider id.
   repeated string pvNames = 2; // List of PV names with buckets using provider.
-  dp.service.common.Timestamp firstBucketTime = 3; // Timstamp of first bucket using provider.
+  dp.service.common.Timestamp firstBucketTime = 3; // Timestamp of first bucket using provider.
   dp.service.common.Timestamp lastBucketTime = 4; // Timestamp of most recent bucket using provider.
   int32 numBuckets = 5; // Number of buckets using provider.
 }


### PR DESCRIPTION
# dp-grpc #117: PV metadata API

## Summary

This PR adds a PV metadata API to `DpAnnotationService`, enabling MLDP users to
associate user-defined metadata (aliases, tags, attributes, description) with PVs
and use that metadata to discover and identify PVs of interest for time-series data
queries and other API calls.

It also renames two existing `DpQueryService` methods to better reflect their
purpose, and establishes a standard CRUD pattern documented in `CLAUDE.md` for
metadata APIs in this service.

## Changes

### `common.proto` — new `PvMetadata` message

A `PvMetadata` message is added as a top-level type alongside `ColumnMetadata`.
Placing it in `common.proto` allows any service to reference it in the future
without creating cross-service import cycles.

Fields: `pvName`, `aliases`, `tags`, `attributes`, `createdTime`, `updatedTime`,
`modifiedBy`, `description`.

### `annotation.proto` — new PV metadata RPC methods and messages

Six new RPC methods added to `DpAnnotationService`:

| Method | Description | Status |
|---|---|---|
| `savePvMetadata()` | Full-replace upsert of a PV metadata record | Implemented |
| `queryPvMetadata()` | Structured multi-criterion search with cursor pagination | Implemented |
| `getPvMetadata()` | Single-record lookup by PV name or alias | Implemented |
| `deletePvMetadata()` | Delete record by canonical PV name | Implemented |
| `patchPvMetadata()` | Partial update via field mask | Not yet implemented |
| `bulkSavePvMetadata()` | Bulk full-replace upsert for large imports | Not yet implemented |

The two unimplemented methods are included to reserve their names and establish
the standard CRUD pattern. Both return an error response if called.

**Query design highlights:**

- `QueryPvMetadataRequest` uses `repeated QueryPvMetadataCriterion criteria`
  (consistent with existing annotation and query service naming). Multiple criteria
  are ANDed; values within a criterion are ORed.
- `PvNameCriterion` and `AliasesCriterion` each support `exact`, `prefix`, and
  `contains` sub-lists.
- `AttributesCriterion` uses an empty `values` list to mean key-only (existence)
  search — no `keyOnly` flag.
- Cursor-based pagination via `limit` + `pageToken` / `nextPageToken`. No
  `totalCount` field — obtaining it would require an expensive separate MongoDB
  count query on every page fetch.

**`savePvMetadata()` semantics:** full replace — all fields are replaced on
update. `patchPvMetadata()` (future) will provide partial-update semantics.
The request comment warns callers explicitly.

### `query.proto` — method renames

Two `DpQueryService` methods renamed to accurately reflect that they return
archive ingestion statistics, not user-defined metadata, and to free up the
name `queryPvMetadata` for the new annotation service method:

| Old name | New name |
|---|---|
| `queryPvMetadata()` | `queryPvStats()` |
| `queryProviderMetadata()` | `queryProviderStats()` |

Corresponding request, response, and result message types renamed throughout
(`QueryPvStatsRequest`, `QueryPvStatsResponse`, `PvStats`, `StatsResult`,
`QueryProviderStatsRequest`, `QueryProviderStatsResponse`, `ProviderStats`).

> **Note:** These are breaking changes for existing clients of `DpQueryService`.

### `CLAUDE.md` — CRUD pattern documentation

A new "CRUD Pattern for Metadata APIs" section documents the standard method
set, pagination design, query criterion conventions, `save*` full-replace warning
requirement, and the deferred-method comment template. The PV metadata API is
the reference implementation of this pattern for future APIs.

## Related

- Closes dp-grpc #117
- Handler implementation: dp-service #178