### PR TITLE
dp-grpc #120 proto changes for initial machine configuration API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ pom.xml               # Maven build; runs protoc via protobuf-maven-plugin
 | `common.proto` | Shared data structures used by all services |
 | `ingestion.proto` | DpIngestionService — provider registration, data ingestion, subscriptions, request status |
 | `query.proto` | DpQueryService — time-series data query, PV metadata query, provider query |
-| `annotation.proto` | DpAnnotationService — DataSets, Annotations, Calculations, data export |
+| `annotation.proto` | DpAnnotationService — PV metadata, machine configuration, DataSets, Annotations, Calculations, data export |
 | `ingestion_stream.proto` | DpIngestionStreamService — data event subscriptions |
 
 Proto files are compiled by the `protobuf-maven-plugin` (0.6.1) using `protoc` and `grpc-java`. Generated Java sources land in `target/generated-sources/`.
@@ -42,6 +42,14 @@ Data is stored and transmitted in **column-oriented** vectors, one column per PV
 - **Deprecated**: `DataColumn` / `DataValue` (per-sample allocation; avoid for new ingestion)
 
 Each column message carries an optional `ColumnMetadata metadata = 10` field (added in issue #116) containing `ColumnProvenance` (source/process), `tags`, and `attributes`.
+
+### Configuration and ConfigurationActivation (`common.proto`)
+Shared messages for the machine configuration API (added in issue #120):
+
+- **`Configuration`** — reusable machine configuration definition. `configurationName` is the canonical primary key. Fields: `category` (required), `description`, `parentConfigurationName`, `tags`, `attributes`, `createdTime`, `updatedTime`, `modifiedBy`.
+- **`ConfigurationActivation`** — time interval during which a Configuration was active. Fields: `clientActivationId` (optional client-supplied key; server-generates if absent), `configurationName`, `startTime`, `endTime` (absent = open-ended), `description`, `tags`, `attributes`, `createdTime`, `updatedTime`, `modifiedBy`.
+
+Placed in `common.proto` so query and other services can reference them without import cycles.
 
 ### DataFrame (`common.proto`)
 The unit of ingestion. Contains `DataTimestamps` (either a `SamplingClock` or explicit `TimestampList`) plus lists of the column message types above.
@@ -78,8 +86,11 @@ All response messages use a `oneof result` with either `ExceptionalResult` (reje
 - `queryProviderMetadata` — ingestion statistics for a provider
 
 ### DpAnnotationService (`annotation.proto`)
-- `createDataSet` / `queryDataSets` — manage DataSets (blocks of PVs × time ranges)
-- `createAnnotation` / `queryAnnotations` — manage Annotations (text, tags, attributes, Calculations, provenance)
+- `savePvMetadata` / `queryPvMetadata` / `getPvMetadata` / `deletePvMetadata` — PV metadata CRUD (`patchPvMetadata` / `bulkSavePvMetadata` deferred stubs)
+- `saveConfiguration` / `queryConfigurations` / `getConfiguration` / `deleteConfiguration` — machine configuration definition CRUD (`patchConfiguration` / `bulkSaveConfiguration` deferred stubs)
+- `saveConfigurationActivation` / `queryConfigurationActivations` / `getConfigurationActivation` / `deleteConfigurationActivation` / `getActiveConfigurations` — configuration activation CRUD and point-in-time query (`patchConfigurationActivation` / `bulkSaveConfigurationActivation` deferred stubs)
+- `saveDataSet` / `queryDataSets` — manage DataSets (blocks of PVs × time ranges)
+- `saveAnnotation` / `queryAnnotations` — manage Annotations (text, tags, attributes, Calculations, provenance)
 - `exportData` — export DataSets and/or Calculations to HDF5, CSV, or XLSX
 
 ### DpIngestionStreamService (`ingestion_stream.proto`)
@@ -99,6 +110,8 @@ All response messages use a `oneof result` with either `ExceptionalResult` (reje
 Metadata APIs follow a standard CRUD method set. `DpAnnotationService.savePvMetadata` /
 `queryPvMetadata` / `getPvMetadata` / `deletePvMetadata` / `patchPvMetadata` /
 `bulkSavePvMetadata` is the reference implementation of this pattern.
+`saveConfiguration` / `saveConfigurationActivation` and their associated CRUD methods
+are a second implementation of this pattern.
 
 **Standard method set:**
 
@@ -125,6 +138,19 @@ do not add a `keyOnly` flag.
 **`save*` full-replace warning**: comments on `Save*Request` must explicitly warn that all
 fields are replaced on update and callers must supply the complete desired state. Reference
 `patch*` as the future partial-update path.
+
+**`Save*Request` flat fields**: request messages must list only client-settable fields
+explicitly — do not embed the full domain message (e.g., `Configuration`,
+`ConfigurationActivation`) since those contain server-set audit fields (`createdTime`,
+`updatedTime`) that must not be accepted as input. Add a `Note:` comment stating that
+audit timestamps are server-set and returned in query/get responses only.
+
+**Optional client-supplied key** (`clientActivationId` pattern): when an entity may be
+loaded from an external system (e.g., a calendar), provide an optional client-supplied
+string key. The server generates an opaque ID if omitted. `get*` and `delete*` and
+`patch*` requests for such entities use `oneof key` accepting either the client key or a
+composite natural key (e.g., `configurationName` + `startTime`). The generated ID is
+returned in the save result so callers can retain it.
 
 **Deferred methods** (`patch*`, `bulkSave*`): include the RPC stub and request/response
 messages in the proto even when not yet implemented, to reserve names and establish the

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This document includes the following information:
   - [PV Time-Series Data API](#pv-time-series-data-api)
   - [Ingestion Request Status API](#ingestion-request-status-api)
   - [PV Metadata API](#pv-metadata-api)
+  - [Machine Configuration API](#machine-configuration-api)
+  - [Configuration Activation API](#configuration-activation-api)
   - [Data Set API](#data-set-api)
   - [Annotation API](#annotation-api)
 - [Data Platform API conventions](#data-platform-API-conventions)
@@ -59,7 +61,7 @@ The core feature of the Query Service API is retrieval of PV time-series data ov
 
 ### Annotation Service API
 
-The Annotation Service API provides tools for augmenting the PV time-series data archive with facility-specific information.  The core feature is identifying datasets, each containing blocks of data defined by a list of PVs and a range of time, and adding annotations to those datasets.  An annotation includes descriptive elements like freeform text comment, keywords, and key-value attributes, and may also include user-defined calculations that use links for tracking data provenance.  The API also includes tools for exporting datasets and calculations to common file formats including HDF5, CSV, and XLSX.  A PV metadata API is provided for associating user-defined metadata (aliases, tags, attributes, description) with PVs and using that metadata to discover PVs of interest.
+The Annotation Service API provides tools for augmenting the PV time-series data archive with facility-specific information.  The core feature is identifying datasets, each containing blocks of data defined by a list of PVs and a range of time, and adding annotations to those datasets.  An annotation includes descriptive elements like freeform text comment, keywords, and key-value attributes, and may also include user-defined calculations that use links for tracking data provenance.  The API also includes tools for exporting datasets and calculations to common file formats including HDF5, CSV, and XLSX.  A PV metadata API is provided for associating user-defined metadata (aliases, tags, attributes, description) with PVs and using that metadata to discover PVs of interest.  A machine configuration API is also provided for recording and querying the operational state of the accelerator at a point in time, including reusable configuration definitions (e.g., `TopOff`, `3GeV`, `UserOps`) and time-stamped activation intervals that can be loaded from operational calendars or recorded in real time.
 
 ### Ingestion Stream Service API
 
@@ -86,7 +88,7 @@ The table below gives an overview of the Data Platform API organized by service.
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Ingestion        | [Provider&nbsp;registration](#provider-registration-methods)<br>[PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Request&nbsp;Status&nbsp;query](#request-status-query-methods)<br>                                                                                                                                                                      |
 | Query            | [PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;stats&nbsp;query](#provider-stats-query-methods)<br>                                                                                                                                                                                                        |
-| Annotation       | [PV&nbsp;metadata&nbsp;save](#pv-metadata-save-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[PV&nbsp;metadata&nbsp;get](#pv-metadata-get-methods)<br>[PV&nbsp;metadata&nbsp;delete](#pv-metadata-delete-methods)<br>[Data&nbsp;Set&nbsp;save](#data-set-save-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;export](#data-export-methods)<br>[Annotation&nbsp;save](#annotation-save-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br> |
+| Annotation       | [PV&nbsp;metadata&nbsp;save](#pv-metadata-save-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[PV&nbsp;metadata&nbsp;get](#pv-metadata-get-methods)<br>[PV&nbsp;metadata&nbsp;delete](#pv-metadata-delete-methods)<br>[Configuration&nbsp;save](#configuration-save-methods)<br>[Configuration&nbsp;query](#configuration-query-methods)<br>[Configuration&nbsp;Activation&nbsp;save](#configuration-activation-save-methods)<br>[Configuration&nbsp;Activation&nbsp;query](#configuration-activation-query-methods)<br>[Data&nbsp;Set&nbsp;save](#data-set-save-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;export](#data-export-methods)<br>[Annotation&nbsp;save](#annotation-save-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br> |
 | Ingestion Stream | [Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>                                                                                                                                                                                                                                                                                                                                                             |
 
 ---
@@ -100,6 +102,8 @@ The table below gives an overview of the Data Platform API organized by entity. 
 | PV Time-Series Data | The core of the MLDP archive is correlated PV time-series data captured from devices in an accelerator facility. | [PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>      |
 | PV Metadata | User-defined metadata associated with a PV, including aliases, tags, key-value attributes, and description.  Used to discover and identify PVs of interest. | [PV&nbsp;metadata&nbsp;save](#pv-metadata-save-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[PV&nbsp;metadata&nbsp;get](#pv-metadata-get-methods)<br>[PV&nbsp;metadata&nbsp;delete](#pv-metadata-delete-methods)<br>                                                                               |
 | Ingestion Request Status | Data ingestion requests are handled asynchronously to maximize performance, so the disposition of individual requests is recorded in a Request Status record. | [Request&nbsp;Status&nbsp;query](#request-status-query-methods)<br>                                                                                                                                                                                                                                                            |
+| Machine Configuration | A reusable named definition of a machine mode or operational state (e.g., `TopOff`, `3GeV`, `UserOps`), belonging to a category, with optional parent hierarchy, tags, and attributes.  Used to describe the accelerator state for interpretation of associated PV data. | [Configuration&nbsp;save](#configuration-save-methods)<br>[Configuration&nbsp;query](#configuration-query-methods)<br>                                                                                                                                                                                    |
+| Configuration Activation | A time interval during which a Machine Configuration was active.  Supports both live recording and retroactive loading from operational calendars.  Multiple configurations may be active simultaneously if they belong to different categories. | [Configuration&nbsp;Activation&nbsp;save](#configuration-activation-save-methods)<br>[Configuration&nbsp;Activation&nbsp;query](#configuration-activation-query-methods)<br>                                                                                                                              |
 | Data Set | A Data Set identifies PV data of interest in the archive through the use of Data Blocks, each one identifying a list of PVs and range of time. | [Data&nbsp;Set&nbsp;save](#data-set-save-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;Set&nbsp;export](#data-set-export-methods)<br>                                                                                                                                                          |
 | Annotation | Annotations are used to annotate Data Sets in the archive with descriptive information, data associations, Calculations, and provenance tracking information. | [Annotation&nbsp;save](#annotation-save-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br>                                                                                                                                                                                                                    |
 
@@ -114,6 +118,9 @@ The Data Platform API is intended to support the following use cases and pattern
 - Monitor ingestion Request Status records for errors and other problems.
 - Query PV time-series data and archive ingestion statistics.
 - Save and query user-defined PV metadata (aliases, tags, attributes, description) to discover and identify PVs of interest.
+- Record machine configurations and the time intervals during which they were active, either in real time or by loading from operational calendars.
+- Query which machine configurations were active at a specific point in time or during a time range.
+- Correlate PV time-series data with machine configuration state for analysis and comparison (e.g., compare orbit data during TopOff vs UserOps).
 - Create Data Sets identifying archive data blocks of interest by PVs and time range.
 - Annotate Data Sets by adding descriptive information, linking to associated other Data Sets and Annotations, adding user-defined Calculations, and tracking data provenance.
 - Query Annotations and identify Data Sets of interest.
@@ -695,6 +702,221 @@ rpc bulkSavePvMetadata(BulkSavePvMetadataRequest) returns (BulkSavePvMetadataRes
 **patchPvMetadata()** will provide partial-update semantics, allowing individual fields to be updated without replacing the entire record.  Field mask design is deferred to the release that implements this method.
 
 **bulkSavePvMetadata()** will accept a list of SavePvMetadataRequest messages and apply the same full-replace upsert semantics as savePvMetadata() to each record in a single request.  Intended for large initial imports or bulk synchronization use cases.
+
+</td>
+</tr>
+</table>
+
+
+## Machine Configuration API
+
+The Machine Configuration API, part of the Annotation Service, provides methods for defining and managing reusable machine configuration records that describe the operational state of the accelerator at a given point in time.  This metadata helps users interpret associated PV time-series data — for example, identifying which machine mode was active during a beam loss event, or comparing orbit data across different energy configurations.
+
+A Configuration record stores `configurationName` as its canonical primary key (no pre-registration required), along with a required `category` (e.g., `beam_mode`, `energy`, `destination`), an optional `parentConfigurationName` for hierarchical organization, keyword tags, key-value attributes, a free-text description, and audit timestamps (`createdTime`, `updatedTime`).
+
+For querying the time intervals during which configurations were active, see the [Configuration Activation API](#configuration-activation-api) below.
+
+### Configuration Save Methods
+<table>
+<tr>
+<td><pre>
+rpc saveConfiguration(SaveConfigurationRequest) returns (SaveConfigurationResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+The saveConfiguration() method creates or replaces the metadata record for a machine configuration.  It uses full-replace upsert semantics: if no record exists for the configuration name, a new record is created; if a record already exists, all fields are replaced with the contents of the request.
+
+**Warning:** Fields omitted from the request are not preserved on update — callers must supply the complete desired state on every save.  Use patchConfiguration() (future) for partial updates.
+
+----
+
+A SaveConfigurationRequest includes the required `configurationName` and `category`, and optional fields: `description`, `parentConfigurationName`, `tags`, `attributes`, and `modifiedBy`.  Data normalization rules applied by the service: tags are normalized to a lowercase unique set; attribute keys must be unique within the request.  `createdTime` and `updatedTime` are server-set and are not accepted as input.
+
+----
+
+The response payload is an ExceptionalResult if the request is rejected or an error is encountered, otherwise a SaveConfigurationResult containing the canonical configuration name of the created or updated record.
+
+</td>
+</tr>
+</table>
+
+### Configuration Query Methods
+<table>
+<tr>
+<td><pre>
+rpc getConfiguration(GetConfigurationRequest) returns (GetConfigurationResponse);
+rpc queryConfigurations(QueryConfigurationsRequest) returns (QueryConfigurationsResponse);
+rpc deleteConfiguration(DeleteConfigurationRequest) returns (DeleteConfigurationResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+**getConfiguration()** retrieves a single Configuration record by `configurationName`.  It is a convenience method for the common single-record lookup case.  The response payload is an ExceptionalResult if no record is found or an error is encountered, otherwise the matching Configuration record.
+
+----
+
+**queryConfigurations()** searches Configuration records using structured criteria and returns a paginated result.
+
+A QueryConfigurationsRequest contains a list of QueryConfigurationsCriterion entries and optional pagination parameters (`limit`, `pageToken`).  Multiple criteria are combined with logical AND; values within a single criterion are combined with logical OR.  Criterion types include:
+
+- **NameCriterion** — match by configuration name using exact, prefix, and/or contains sub-lists (all ORed together).
+- **CategoryCriterion** — match records whose category equals any of the specified values.
+- **TagsCriterion** — match records that have any of the specified tags.
+- **AttributesCriterion** — match by attribute key and optional value(s); an empty values list matches any record that has the key regardless of value (key-only / existence search).
+- **ParentCriterion** — match records whose `parentConfigurationName` equals any of the specified values (direct children only; recursive traversal not yet supported).
+
+The response payload is an ExceptionalResult if the request is rejected or an error is encountered, otherwise a QueryConfigurationsResult containing a list of Configuration records and a `nextPageToken` for retrieving subsequent pages.  An empty result set is returned as a QueryConfigurationsResult with an empty list, not an ExceptionalResult.
+
+----
+
+**deleteConfiguration()** deletes the Configuration record for the specified `configurationName`.  The request is rejected if ConfigurationActivation records exist for the configuration; delete associated activations first.  The response payload is an ExceptionalResult if rejected or an error is encountered, otherwise a DeleteConfigurationResult confirming the name of the deleted record.
+
+</td>
+</tr>
+</table>
+
+### Configuration Placeholder Methods
+
+Two additional Configuration methods are defined in the proto but not yet implemented.  Calling either method returns an error response.  They are defined now to reserve their names and establish the standard CRUD pattern for metadata APIs in this service.
+
+<table>
+<tr>
+<td><pre>
+rpc patchConfiguration(PatchConfigurationRequest) returns (PatchConfigurationResponse);
+rpc bulkSaveConfiguration(BulkSaveConfigurationRequest) returns (BulkSaveConfigurationResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+**patchConfiguration()** will provide partial-update semantics, allowing individual fields to be updated without replacing the entire record.  Field mask design is deferred to the release that implements this method.
+
+**bulkSaveConfiguration()** will accept a list of SaveConfigurationRequest messages and apply the same full-replace upsert semantics as saveConfiguration() to each record in a single request.  Intended for large initial imports or bulk synchronization use cases.
+
+</td>
+</tr>
+</table>
+
+
+## Configuration Activation API
+
+The Configuration Activation API, part of the Annotation Service, provides methods for recording and querying the time intervals during which machine configurations were active.  A ConfigurationActivation record links a Configuration to a `startTime` and optional `endTime` (absent means the interval is open-ended).
+
+The primary use case is bulk-loading activation history from operational calendars, but live recording is also supported.  Multiple configurations may be active simultaneously as long as they belong to different categories — the server enforces that no two activations for the same configuration name, or within the same category, overlap.
+
+An optional `clientActivationId` field allows callers to supply a stable external identifier for an activation record (e.g., a calendar event ID).  If omitted, the server generates an opaque identifier.  Clients loading activations from external systems should always supply `clientActivationId` to enable future updates without a prior lookup.
+
+### Configuration Activation Save Methods
+<table>
+<tr>
+<td><pre>
+rpc saveConfigurationActivation(SaveConfigurationActivationRequest) returns (SaveConfigurationActivationResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+The saveConfigurationActivation() method creates or replaces an activation record.  It uses full-replace upsert semantics: the record is matched for update by `clientActivationId` if provided, otherwise by composite key (`configurationName` + `startTime`).
+
+**Warning:** Fields omitted from the request are not preserved on update — callers must supply the complete desired state on every save.  Use patchConfigurationActivation() (future) for partial updates.
+
+To close an open-ended activation, call saveConfigurationActivation() with `endTime` set to the desired close time.
+
+----
+
+A SaveConfigurationActivationRequest includes the required `configurationName` and `startTime`, optional `clientActivationId`, `endTime`, `description`, `tags`, `attributes`, and `modifiedBy`.  `createdTime` and `updatedTime` are server-set and are not accepted as input.
+
+Validation rules: `configurationName` must reference an existing Configuration record; if `endTime` is present it must be >= `startTime`; overlapping activations for the same `configurationName` or within the same category are rejected.
+
+----
+
+The response payload is an ExceptionalResult if the request is rejected or an error is encountered, otherwise a SaveConfigurationActivationResult containing the `clientActivationId` of the created or updated record (client-supplied or server-generated).
+
+</td>
+</tr>
+</table>
+
+### Configuration Activation Query Methods
+<table>
+<tr>
+<td><pre>
+rpc getConfigurationActivation(GetConfigurationActivationRequest) returns (GetConfigurationActivationResponse);
+rpc queryConfigurationActivations(QueryConfigurationActivationsRequest) returns (QueryConfigurationActivationsResponse);
+rpc deleteConfigurationActivation(DeleteConfigurationActivationRequest) returns (DeleteConfigurationActivationResponse);
+rpc getActiveConfigurations(GetActiveConfigurationsRequest) returns (GetActiveConfigurationsResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+**getConfigurationActivation()** retrieves a single ConfigurationActivation record by `clientActivationId` or composite key (`configurationName` + `startTime`).  Exactly one key must be set.  The response payload is an ExceptionalResult if no record is found or an error is encountered, otherwise the matching ConfigurationActivation record.
+
+----
+
+**queryConfigurationActivations()** searches ConfigurationActivation records using structured criteria and returns a paginated result.
+
+A QueryConfigurationActivationsRequest contains a list of QueryConfigurationActivationsCriterion entries and optional pagination parameters (`limit`, `pageToken`).  Multiple criteria are combined with logical AND; values within a single criterion are combined with logical OR.  Criterion types include:
+
+- **TimestampCriterion** — match activations in effect at a specific point in time (`startTime <= timestamp` AND (`endTime` is absent OR `endTime > timestamp`)).
+- **TimeRangeCriterion** — match activations that overlap a specified window (activation is active at any point during `[startTime, endTime)`).
+- **ConfigurationNameCriterion** — match by configuration name (exact match, OR semantics).
+- **ClientActivationIdCriterion** — match by client-supplied activation ID (exact match, OR semantics).
+- **CategoryCriterion** — match activations whose configuration belongs to any of the specified categories.
+- **TagsCriterion** — match activations that have any of the specified tags.
+- **AttributesCriterion** — match by attribute key and optional value(s); an empty values list matches any activation that has the key (key-only / existence search).
+
+The response payload is an ExceptionalResult if the request is rejected or an error is encountered, otherwise a QueryConfigurationActivationsResult containing a list of ConfigurationActivation records and a `nextPageToken` for retrieving subsequent pages.  An empty result set is returned as a QueryConfigurationActivationsResult with an empty list, not an ExceptionalResult.
+
+----
+
+**deleteConfigurationActivation()** deletes an activation record by `clientActivationId` or composite key (`configurationName` + `startTime`).  The response payload is an ExceptionalResult if rejected or an error is encountered, otherwise a DeleteConfigurationActivationResult confirming the `clientActivationId` of the deleted record.
+
+----
+
+**getActiveConfigurations()** returns all ConfigurationActivation records in effect at the specified timestamp.  The `timestamp` field is required; a zero-value timestamp is rejected with an ExceptionalResult.  An empty result (no active configurations at the specified time) is returned as a GetActiveConfigurationsResult with an empty list, not an ExceptionalResult.
+
+</td>
+</tr>
+</table>
+
+### Configuration Activation Placeholder Methods
+
+Two additional Configuration Activation methods are defined in the proto but not yet implemented.  Calling either method returns an error response.  They are defined now to reserve their names and establish the standard CRUD pattern for metadata APIs in this service.
+
+<table>
+<tr>
+<td><pre>
+rpc patchConfigurationActivation(PatchConfigurationActivationRequest) returns (PatchConfigurationActivationResponse);
+rpc bulkSaveConfigurationActivation(BulkSaveConfigurationActivationRequest) returns (BulkSaveConfigurationActivationResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: annotation.proto</td>
+</tr>
+<tr>
+<td>
+
+**patchConfigurationActivation()** will provide partial-update semantics, allowing individual fields (e.g., `endTime`) to be updated without replacing the entire record.  Field mask design is deferred to the release that implements this method.
+
+**bulkSaveConfigurationActivation()** will accept a list of SaveConfigurationActivationRequest messages and apply the same full-replace upsert semantics as saveConfigurationActivation() to each record in a single request.  Intended for bulk loading of activation records from operational calendars.
 
 </td>
 </tr>

--- a/src/main/proto/annotation.proto
+++ b/src/main/proto/annotation.proto
@@ -1171,13 +1171,22 @@ message BulkSavePvMetadataResponse {
  * Callers must supply the complete desired state on every save.
  * patchConfiguration() (future placeholder) will provide partial-update semantics.
  *
+ * Note: createdTime and updatedTime are server-set audit timestamps and are
+ * not accepted as input; they are returned in query and get responses only.
+ *
  * Data normalization rules applied by the service:
  *   - tags are normalized to a lowercase unique set.
  *   - attribute keys (Attribute.name) must be unique within the request;
  *     duplicate keys are rejected.
  */
 message SaveConfigurationRequest {
-  dp.service.common.Configuration configuration = 1;
+  string configurationName = 1;       // required canonical configuration name
+  string category = 2;                // required
+  string description = 3;             // optional free-text description
+  string parentConfigurationName = 4; // optional parent configuration name
+  repeated string tags = 5;           // optional keyword tags
+  repeated dp.service.common.Attribute attributes = 6; // optional key/value attribute pairs
+  string modifiedBy = 7;              // optional actor / user / service identity
 }
 
 /*
@@ -1519,10 +1528,14 @@ message BulkSaveConfigurationResponse {
      * BulkSaveError
      *
      * Describes a failure for a single record within a bulk save request.
+     * requestIndex is the 0-based position of the failed record in the
+     * requests list, providing a stable correlation reference regardless
+     * of whether configurationName was supplied.
      */
     message BulkSaveError {
-      string configurationName = 1;
-      dp.service.common.ExceptionalResult exceptionalResult = 2;
+      uint32 requestIndex = 1;
+      string configurationName = 2;
+      dp.service.common.ExceptionalResult exceptionalResult = 3;
     }
   }
 }
@@ -1551,6 +1564,9 @@ message BulkSaveConfigurationResponse {
  * To close an open-ended activation, call saveConfigurationActivation() with
  * endTime set to the desired close time.
  *
+ * Note: createdTime and updatedTime are server-set audit timestamps and are
+ * not accepted as input; they are returned in query and get responses only.
+ *
  * Validation rules applied by the service:
  *   - configurationName must reference an existing Configuration record.
  *   - startTime is required.
@@ -1561,7 +1577,14 @@ message BulkSaveConfigurationResponse {
  *   - Duplicate attribute keys (Attribute.name) are rejected.
  */
 message SaveConfigurationActivationRequest {
-  dp.service.common.ConfigurationActivation configurationActivation = 1;
+  string clientActivationId = 1;      // optional client-supplied primary key; server-generated if absent
+  string configurationName = 2;       // required; references a Configuration record
+  dp.service.common.Timestamp startTime = 3;           // required
+  dp.service.common.Timestamp endTime = 4;             // optional; absent = open-ended interval
+  string description = 5;             // optional free-text description
+  repeated string tags = 6;           // optional keyword tags
+  repeated dp.service.common.Attribute attributes = 7; // optional key/value attribute pairs
+  string modifiedBy = 8;              // optional actor / user / service identity
 }
 
 /*
@@ -1870,14 +1893,32 @@ message DeleteConfigurationActivationResponse {
 /*
  * PatchConfigurationActivationRequest
  *
- * Partial update of an existing ConfigurationActivation record.
+ * Partial update of an existing ConfigurationActivation record.  The record
+ * is identified by clientActivationId or composite key (configurationName +
+ * startTime), matching the same key semantics as getConfigurationActivation()
+ * and deleteConfigurationActivation().
  *
  * NOT YET IMPLEMENTED.  The patch fields and field mask mechanism are deferred
  * to the release that implements patchConfigurationActivation().  This message
  * is defined now to reserve the name and establish the pattern.
  */
 message PatchConfigurationActivationRequest {
-  string clientActivationId = 1; // required
+
+  oneof key {
+    string clientActivationId = 1;
+    CompositeKey compositeKey = 2;
+  }
+
+  /*
+   * CompositeKey
+   *
+   * Identifies a ConfigurationActivation by configurationName and startTime
+   * when clientActivationId is not available.
+   */
+  message CompositeKey {
+    string configurationName = 1;
+    dp.service.common.Timestamp startTime = 2;
+  }
 }
 
 /*
@@ -1958,10 +1999,14 @@ message BulkSaveConfigurationActivationResponse {
      * BulkSaveError
      *
      * Describes a failure for a single record within a bulk save request.
+     * requestIndex is the 0-based position of the failed record in the
+     * requests list, providing a stable correlation reference regardless
+     * of whether clientActivationId was supplied.
      */
     message BulkSaveError {
-      string clientActivationId = 1;
-      dp.service.common.ExceptionalResult exceptionalResult = 2;
+      uint32 requestIndex = 1;
+      string clientActivationId = 2;
+      dp.service.common.ExceptionalResult exceptionalResult = 3;
     }
   }
 }

--- a/src/main/proto/annotation.proto
+++ b/src/main/proto/annotation.proto
@@ -153,6 +153,205 @@ service DpAnnotationService {
    * of the standard bulk-write pattern for metadata APIs in this service.
    */
   rpc bulkSavePvMetadata(BulkSavePvMetadataRequest) returns (BulkSavePvMetadataResponse);
+
+
+  //
+  // ------------------- Configuration Definition CRUD ---------------------------
+  //
+
+  /*
+   * saveConfiguration()
+   *
+   * Create or replace the metadata record for the specified machine configuration.
+   *
+   * Full replace (upsert) semantics: if a record does not exist it is created;
+   * if a record already exists, ALL fields (category, description,
+   * parentConfigurationName, tags, attributes, modifiedBy) are replaced with
+   * the request contents.  Callers must supply the complete desired state on
+   * every call — fields omitted from the request are not preserved.
+   * Use patchConfiguration() (future) for partial updates.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * successful handling of the request.
+   */
+  rpc saveConfiguration(SaveConfigurationRequest) returns (SaveConfigurationResponse);
+
+  /*
+   * getConfiguration()
+   *
+   * Retrieve a single Configuration record by configurationName.
+   * Provided as a convenience over queryConfigurations() for the common
+   * single-record lookup case.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a GetConfigurationResult containing the matching record.  If no record
+   * is found, an ExceptionalResult is returned.
+   */
+  rpc getConfiguration(GetConfigurationRequest) returns (GetConfigurationResponse);
+
+  /*
+   * queryConfigurations()
+   *
+   * Query Configuration records using structured search criteria.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a QueryConfigurationsResult containing the matching records and pagination token.
+   */
+  rpc queryConfigurations(QueryConfigurationsRequest) returns (QueryConfigurationsResponse);
+
+  /*
+   * deleteConfiguration()
+   *
+   * Delete the Configuration record for the specified configurationName.
+   * The request is rejected if ConfigurationActivation records exist for the
+   * configuration; delete associated activations first.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a DeleteConfigurationResult confirming the name of the deleted record.
+   */
+  rpc deleteConfiguration(DeleteConfigurationRequest) returns (DeleteConfigurationResponse);
+
+  /*
+   * patchConfiguration()
+   *
+   * Partial update of an existing Configuration record.  Allows individual
+   * fields to be updated without replacing the entire record, unlike the
+   * full-replace semantics of saveConfiguration().
+   *
+   * NOT YET IMPLEMENTED — calling this method returns an error response.
+   * Planned for a future release.
+   *
+   * This method is defined now to reserve its name and message shapes as part
+   * of the standard CRUD pattern for metadata APIs in this service.
+   */
+  rpc patchConfiguration(PatchConfigurationRequest) returns (PatchConfigurationResponse);
+
+  /*
+   * bulkSaveConfiguration()
+   *
+   * Bulk create or replace multiple Configuration records in a single request.
+   * Each record uses the same full-replace upsert semantics as saveConfiguration().
+   * Intended for large initial imports or bulk synchronization use cases.
+   *
+   * NOT YET IMPLEMENTED — calling this method returns an error response.
+   * Planned for a future release.
+   *
+   * This method is defined now to reserve its name and message shapes as part
+   * of the standard bulk-write pattern for metadata APIs in this service.
+   */
+  rpc bulkSaveConfiguration(BulkSaveConfigurationRequest) returns (BulkSaveConfigurationResponse);
+
+
+  //
+  // ------------------- Configuration Activation CRUD ---------------------------
+  //
+
+  /*
+   * saveConfigurationActivation()
+   *
+   * Create or replace an activation record indicating the time interval during
+   * which a Configuration was active.
+   *
+   * Full replace (upsert) semantics: if a record does not exist it is created;
+   * if a record already exists (matched by clientActivationId, or by composite
+   * key configurationName + startTime if clientActivationId is absent), ALL
+   * fields are replaced with the request contents.  Callers must supply the
+   * complete desired state on every call — fields omitted from the request are
+   * not preserved.  Use patchConfigurationActivation() (future) for partial updates.
+   *
+   * To close an open-ended activation, call saveConfigurationActivation() with
+   * endTime set to the desired close time.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * successful handling of the request.
+   */
+  rpc saveConfigurationActivation(SaveConfigurationActivationRequest) returns (SaveConfigurationActivationResponse);
+
+  /*
+   * getConfigurationActivation()
+   *
+   * Retrieve a single ConfigurationActivation record by clientActivationId or
+   * composite key (configurationName + startTime).
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a GetConfigurationActivationResult containing the matching record.  If no
+   * record is found, an ExceptionalResult is returned.
+   */
+  rpc getConfigurationActivation(GetConfigurationActivationRequest) returns (GetConfigurationActivationResponse);
+
+  /*
+   * queryConfigurationActivations()
+   *
+   * Query ConfigurationActivation records using structured search criteria.
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a QueryConfigurationActivationsResult containing the matching records and
+   * pagination token.
+   */
+  rpc queryConfigurationActivations(QueryConfigurationActivationsRequest) returns (QueryConfigurationActivationsResponse);
+
+  /*
+   * deleteConfigurationActivation()
+   *
+   * Delete a ConfigurationActivation record by clientActivationId or composite
+   * key (configurationName + startTime).
+   *
+   * The response may indicate rejection, an error handling the request, or
+   * a DeleteConfigurationActivationResult confirming the ID of the deleted record.
+   */
+  rpc deleteConfigurationActivation(DeleteConfigurationActivationRequest) returns (DeleteConfigurationActivationResponse);
+
+  /*
+   * patchConfigurationActivation()
+   *
+   * Partial update of an existing ConfigurationActivation record.  Allows
+   * individual fields to be updated without replacing the entire record, unlike
+   * the full-replace semantics of saveConfigurationActivation().
+   *
+   * NOT YET IMPLEMENTED — calling this method returns an error response.
+   * Planned for a future release.
+   *
+   * This method is defined now to reserve its name and message shapes as part
+   * of the standard CRUD pattern for metadata APIs in this service.
+   */
+  rpc patchConfigurationActivation(PatchConfigurationActivationRequest) returns (PatchConfigurationActivationResponse);
+
+  /*
+   * bulkSaveConfigurationActivation()
+   *
+   * Bulk create or replace multiple ConfigurationActivation records in a single
+   * request.  Each record uses the same full-replace upsert semantics as
+   * saveConfigurationActivation().  Intended for bulk loading of activation
+   * records from operational calendars.
+   *
+   * NOT YET IMPLEMENTED — calling this method returns an error response.
+   * Planned for a future release.
+   *
+   * This method is defined now to reserve its name and message shapes as part
+   * of the standard bulk-write pattern for metadata APIs in this service.
+   */
+  rpc bulkSaveConfigurationActivation(BulkSaveConfigurationActivationRequest) returns (BulkSaveConfigurationActivationResponse);
+
+
+  //
+  // ------------------- Active Configuration Query ---------------------------
+  //
+
+  /*
+   * getActiveConfigurations()
+   *
+   * Returns all ConfigurationActivation records in effect at the specified
+   * timestamp, i.e., records where:
+   *   startTime <= timestamp AND (endTime is absent OR endTime > timestamp)
+   *
+   * timestamp is required.  Requests with an absent (zero-value) timestamp
+   * are rejected with an ExceptionalResult.
+   *
+   * An empty result (no active configurations at the specified time) is
+   * returned as a GetActiveConfigurationsResult with an empty list, not
+   * an ExceptionalResult.
+   */
+  rpc getActiveConfigurations(GetActiveConfigurationsRequest) returns (GetActiveConfigurationsResponse);
 }
 
 
@@ -949,5 +1148,870 @@ message BulkSavePvMetadataResponse {
       string pvName = 1;
       dp.service.common.ExceptionalResult exceptionalResult = 2;
     }
+  }
+}
+
+
+//
+// ------------------- Configuration Definition Save Request/Response ---------------------------
+//
+
+/*
+ * SaveConfigurationRequest
+ *
+ * Encapsulates the details for creating or replacing a Configuration record.
+ *
+ * Full replace (upsert) semantics:
+ *   - If no record exists for configurationName, a new record is created.
+ *   - If a record already exists, ALL fields (category, description,
+ *     parentConfigurationName, tags, attributes, modifiedBy) are replaced
+ *     with the values in this request.
+ *
+ * WARNING: Fields omitted from the request are NOT preserved on update.
+ * Callers must supply the complete desired state on every save.
+ * patchConfiguration() (future placeholder) will provide partial-update semantics.
+ *
+ * Data normalization rules applied by the service:
+ *   - tags are normalized to a lowercase unique set.
+ *   - attribute keys (Attribute.name) must be unique within the request;
+ *     duplicate keys are rejected.
+ */
+message SaveConfigurationRequest {
+  dp.service.common.Configuration configuration = 1;
+}
+
+/*
+ * SaveConfigurationResponse
+ *
+ * Contains the response to a saveConfiguration() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a SaveConfigurationResult.
+ */
+message SaveConfigurationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    SaveConfigurationResult saveConfigurationResult = 11;
+  }
+
+  /*
+   * SaveConfigurationResult
+   *
+   * Contains the result of a successful saveConfiguration() request.
+   */
+  message SaveConfigurationResult {
+    string configurationName = 1; // canonical name of the created or updated record
+  }
+}
+
+
+//
+// ------------------- Configuration Definition Get Request/Response ---------------------------
+//
+
+/*
+ * GetConfigurationRequest
+ *
+ * Retrieve a single Configuration record by canonical configuration name.
+ */
+message GetConfigurationRequest {
+  string configurationName = 1; // required canonical configuration name
+}
+
+/*
+ * GetConfigurationResponse
+ *
+ * Contains the result of a getConfiguration() request.  Payload is an
+ * ExceptionalResult if the request is rejected, an error is encountered, or
+ * no record is found, otherwise contains a GetConfigurationResult with the
+ * matching Configuration record.
+ */
+message GetConfigurationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    GetConfigurationResult getConfigurationResult = 11;
+  }
+
+  /*
+   * GetConfigurationResult
+   *
+   * Contains the result of a successful getConfiguration() request.
+   */
+  message GetConfigurationResult {
+    dp.service.common.Configuration configuration = 1;
+  }
+}
+
+
+//
+// ------------------- Configuration Definition Query ---------------------------
+//
+
+/*
+ * QueryConfigurationsRequest
+ *
+ * Contains parameters for a Configuration query using structured search criteria.
+ *
+ * Combining semantics:
+ *   - Multiple criteria in the top-level list are combined with logical AND:
+ *     a record must satisfy ALL criteria to be returned.
+ *   - Within a single criterion, multiple values are combined with logical OR:
+ *     a record satisfies the criterion if it matches ANY supplied value.
+ *   - An empty criteria list is rejected with an ExceptionalResult; at least
+ *     one criterion is required.
+ *
+ * Pagination:
+ *   - limit specifies the maximum number of records to return per response.
+ *   - pageToken is omitted on the first request; subsequent requests supply
+ *     the nextPageToken returned in the previous response.
+ *   - An empty nextPageToken in the response indicates no further pages.
+ */
+message QueryConfigurationsRequest {
+
+  repeated QueryConfigurationsCriterion criteria = 1;
+
+  uint32 limit = 2;
+  string pageToken = 3;
+
+  /*
+   * QueryConfigurationsCriterion
+   *
+   * A single search criterion.  Exactly one criterion must be set.
+   */
+  message QueryConfigurationsCriterion {
+
+    oneof criterion {
+      NameCriterion nameCriterion = 10;
+      CategoryCriterion categoryCriterion = 11;
+      TagsCriterion tagsCriterion = 12;
+      AttributesCriterion attributesCriterion = 13;
+      ParentCriterion parentCriterion = 14;
+    }
+
+    /*
+     * NameCriterion
+     *
+     * Match Configuration records by name.  Values across all three sub-lists
+     * are ORed: a name matches if it satisfies any supplied value from any sub-list.
+     */
+    message NameCriterion {
+      repeated string exact = 1;    // exact string match
+      repeated string prefix = 2;   // prefix match
+      repeated string contains = 3; // substring match
+    }
+
+    /*
+     * CategoryCriterion
+     *
+     * Match records whose category equals any of the specified values.
+     * Multiple values are ORed.
+     */
+    message CategoryCriterion {
+      repeated string values = 1;
+    }
+
+    /*
+     * TagsCriterion
+     *
+     * Match records that have any of the specified tags.  Multiple tags within
+     * a single TagsCriterion are ORed; use separate TagsCriterion entries in
+     * the outer criteria list (ANDed) to require multiple tags simultaneously.
+     */
+    message TagsCriterion {
+      repeated string values = 1;
+    }
+
+    /*
+     * AttributesCriterion
+     *
+     * Match records by attribute key and optional value(s).
+     * key (maps to Attribute.name) is required.
+     * values is optional: if non-empty, the record must have the key with one
+     * of the specified values (OR); if empty, any record possessing the key
+     * matches regardless of its value (key-only / existence search).
+     */
+    message AttributesCriterion {
+      string key = 1;             // required; matches Attribute.name
+      repeated string values = 2; // optional; empty list = key-only search
+    }
+
+    /*
+     * ParentCriterion
+     *
+     * Match records whose parentConfigurationName equals any of the specified
+     * values.  Returns direct children only; recursive hierarchy traversal is
+     * not supported in Phase 1.
+     */
+    message ParentCriterion {
+      repeated string values = 1;
+    }
+  }
+}
+
+/*
+ * QueryConfigurationsResponse
+ *
+ * Contains the results of a queryConfigurations() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a QueryConfigurationsResult with the matching records.
+ *
+ * An empty query result is returned as a QueryConfigurationsResult with an
+ * empty configurations list (not an ExceptionalResult).
+ */
+message QueryConfigurationsResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    QueryConfigurationsResult queryConfigurationsResult = 11;
+  }
+
+  /*
+   * QueryConfigurationsResult
+   *
+   * Contains a page of Configuration records matching the query criteria.
+   *
+   * nextPageToken is non-empty when additional pages are available; supply it
+   * as pageToken in the next request to retrieve the following page.
+   * An empty nextPageToken indicates the last page.
+   */
+  message QueryConfigurationsResult {
+    repeated dp.service.common.Configuration configurations = 1;
+    string nextPageToken = 2;
+  }
+}
+
+
+//
+// ------------------- Configuration Definition Delete / Patch / BulkSave ---------------------------
+//
+
+/*
+ * DeleteConfigurationRequest
+ *
+ * Delete the Configuration record for the specified canonical configuration name.
+ * The request is rejected if ConfigurationActivation records exist for the
+ * configuration; delete associated activations first.
+ */
+message DeleteConfigurationRequest {
+  string configurationName = 1; // required canonical configuration name
+}
+
+/*
+ * DeleteConfigurationResponse
+ *
+ * Contains the result of a deleteConfiguration() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a DeleteConfigurationResult.
+ */
+message DeleteConfigurationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    DeleteConfigurationResult deleteConfigurationResult = 11;
+  }
+
+  /*
+   * DeleteConfigurationResult
+   *
+   * Contains the result of a successful deleteConfiguration() request.
+   */
+  message DeleteConfigurationResult {
+    string configurationName = 1; // canonical name of the deleted record
+  }
+}
+
+/*
+ * PatchConfigurationRequest
+ *
+ * Partial update of an existing Configuration record.
+ *
+ * NOT YET IMPLEMENTED.  The patch fields and field mask mechanism are deferred
+ * to the release that implements patchConfiguration().  This message is defined
+ * now to reserve the name and establish the pattern.
+ */
+message PatchConfigurationRequest {
+  string configurationName = 1; // required canonical configuration name
+}
+
+/*
+ * PatchConfigurationResponse
+ *
+ * Contains the result of a patchConfiguration() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a PatchConfigurationResult.
+ */
+message PatchConfigurationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    PatchConfigurationResult patchConfigurationResult = 11;
+  }
+
+  /*
+   * PatchConfigurationResult
+   *
+   * Contains the result of a successful patchConfiguration() request.
+   */
+  message PatchConfigurationResult {
+    string configurationName = 1; // canonical name of the updated record
+  }
+}
+
+/*
+ * BulkSaveConfigurationRequest
+ *
+ * Bulk create or replace multiple Configuration records in a single request.
+ * Each record uses the same full-replace upsert semantics as saveConfiguration().
+ * Intended for large initial imports or bulk synchronization use cases.
+ *
+ * NOT YET IMPLEMENTED.  This message is defined now to reserve the name and
+ * establish the pattern for bulk-write operations in this service.
+ */
+message BulkSaveConfigurationRequest {
+  repeated SaveConfigurationRequest requests = 1;
+}
+
+/*
+ * BulkSaveConfigurationResponse
+ *
+ * Contains the result of a bulkSaveConfiguration() request.  Payload is an
+ * ExceptionalResult if the entire request is rejected (e.g. validation failure
+ * before any records are processed), otherwise contains a
+ * BulkSaveConfigurationResult reporting the count of successfully saved records
+ * and per-item details for any failures.
+ *
+ * A response with BulkSaveConfigurationResult and a non-empty errors list
+ * indicates a partial failure: some records were saved and some were not.
+ */
+message BulkSaveConfigurationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    BulkSaveConfigurationResult bulkSaveConfigurationResult = 11;
+  }
+
+  /*
+   * BulkSaveConfigurationResult
+   *
+   * savedCount is the number of records successfully saved.
+   * errors contains one entry per failed record; an empty list means all
+   * records were saved successfully.
+   */
+  message BulkSaveConfigurationResult {
+
+    uint32 savedCount = 1;
+    repeated BulkSaveError errors = 2;
+
+    /*
+     * BulkSaveError
+     *
+     * Describes a failure for a single record within a bulk save request.
+     */
+    message BulkSaveError {
+      string configurationName = 1;
+      dp.service.common.ExceptionalResult exceptionalResult = 2;
+    }
+  }
+}
+
+
+//
+// ------------------- Configuration Activation Save Request/Response ---------------------------
+//
+
+/*
+ * SaveConfigurationActivationRequest
+ *
+ * Encapsulates the details for creating or replacing a ConfigurationActivation record.
+ *
+ * Full replace (upsert) semantics:
+ *   - The record is matched for update by clientActivationId if provided,
+ *     otherwise by composite key (configurationName + startTime).
+ *   - If no matching record exists, a new record is created.
+ *   - If a matching record exists, ALL fields are replaced with the values
+ *     in this request.
+ *
+ * WARNING: Fields omitted from the request are NOT preserved on update.
+ * Callers must supply the complete desired state on every save.
+ * patchConfigurationActivation() (future placeholder) will provide partial-update semantics.
+ *
+ * To close an open-ended activation, call saveConfigurationActivation() with
+ * endTime set to the desired close time.
+ *
+ * Validation rules applied by the service:
+ *   - configurationName must reference an existing Configuration record.
+ *   - startTime is required.
+ *   - If endTime is present, endTime must be >= startTime.
+ *   - Overlapping activations for the same configurationName are rejected.
+ *   - Overlapping activations within the same category are rejected.
+ *   - tags are normalized to a lowercase unique set.
+ *   - Duplicate attribute keys (Attribute.name) are rejected.
+ */
+message SaveConfigurationActivationRequest {
+  dp.service.common.ConfigurationActivation configurationActivation = 1;
+}
+
+/*
+ * SaveConfigurationActivationResponse
+ *
+ * Contains the response to a saveConfigurationActivation() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a SaveConfigurationActivationResult.
+ */
+message SaveConfigurationActivationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    SaveConfigurationActivationResult saveConfigurationActivationResult = 11;
+  }
+
+  /*
+   * SaveConfigurationActivationResult
+   *
+   * Contains the result of a successful saveConfigurationActivation() request.
+   */
+  message SaveConfigurationActivationResult {
+    string clientActivationId = 1; // client-supplied or server-generated activation ID
+  }
+}
+
+
+//
+// ------------------- Configuration Activation Get Request/Response ---------------------------
+//
+
+/*
+ * GetConfigurationActivationRequest
+ *
+ * Retrieve a single ConfigurationActivation record by clientActivationId or
+ * composite key (configurationName + startTime).  Exactly one key must be set.
+ */
+message GetConfigurationActivationRequest {
+
+  oneof key {
+    string clientActivationId = 1;
+    CompositeKey compositeKey = 2;
+  }
+
+  /*
+   * CompositeKey
+   *
+   * Identifies a ConfigurationActivation by configurationName and startTime
+   * when clientActivationId is not available.
+   */
+  message CompositeKey {
+    string configurationName = 1;
+    dp.service.common.Timestamp startTime = 2;
+  }
+}
+
+/*
+ * GetConfigurationActivationResponse
+ *
+ * Contains the result of a getConfigurationActivation() request.  Payload is an
+ * ExceptionalResult if the request is rejected, an error is encountered, or no
+ * record is found, otherwise contains a GetConfigurationActivationResult with the
+ * matching ConfigurationActivation record.
+ */
+message GetConfigurationActivationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    GetConfigurationActivationResult getConfigurationActivationResult = 11;
+  }
+
+  /*
+   * GetConfigurationActivationResult
+   *
+   * Contains the result of a successful getConfigurationActivation() request.
+   */
+  message GetConfigurationActivationResult {
+    dp.service.common.ConfigurationActivation configurationActivation = 1;
+  }
+}
+
+
+//
+// ------------------- Configuration Activation Query ---------------------------
+//
+
+/*
+ * QueryConfigurationActivationsRequest
+ *
+ * Contains parameters for a ConfigurationActivation query using structured
+ * search criteria.
+ *
+ * Combining semantics:
+ *   - Multiple criteria in the top-level list are combined with logical AND:
+ *     a record must satisfy ALL criteria to be returned.
+ *   - Within a single criterion, multiple values are combined with logical OR:
+ *     a record satisfies the criterion if it matches ANY supplied value.
+ *   - An empty criteria list is rejected with an ExceptionalResult; at least
+ *     one criterion is required.
+ *
+ * Pagination:
+ *   - limit specifies the maximum number of records to return per response.
+ *   - pageToken is omitted on the first request; subsequent requests supply
+ *     the nextPageToken returned in the previous response.
+ *   - An empty nextPageToken in the response indicates no further pages.
+ */
+message QueryConfigurationActivationsRequest {
+
+  repeated QueryConfigurationActivationsCriterion criteria = 1;
+
+  uint32 limit = 2;
+  string pageToken = 3;
+
+  /*
+   * QueryConfigurationActivationsCriterion
+   *
+   * A single search criterion.  Exactly one criterion must be set.
+   */
+  message QueryConfigurationActivationsCriterion {
+
+    oneof criterion {
+      TimestampCriterion timestampCriterion = 10;
+      TimeRangeCriterion timeRangeCriterion = 11;
+      ConfigurationNameCriterion configurationNameCriterion = 12;
+      ClientActivationIdCriterion clientActivationIdCriterion = 13;
+      CategoryCriterion categoryCriterion = 14;
+      TagsCriterion tagsCriterion = 15;
+      AttributesCriterion attributesCriterion = 16;
+    }
+
+    /*
+     * TimestampCriterion
+     *
+     * Match activations in effect at the specified point in time:
+     *   activation.startTime <= timestamp AND
+     *   (activation.endTime is absent OR activation.endTime > timestamp)
+     */
+    message TimestampCriterion {
+      dp.service.common.Timestamp timestamp = 1;
+    }
+
+    /*
+     * TimeRangeCriterion
+     *
+     * Match activations that overlap the specified time window, i.e., the
+     * activation is active at any point during [startTime, endTime):
+     *   activation.startTime < endTime AND
+     *   (activation.endTime is absent OR activation.endTime > startTime)
+     */
+    message TimeRangeCriterion {
+      dp.service.common.Timestamp startTime = 1;
+      dp.service.common.Timestamp endTime = 2;
+    }
+
+    /*
+     * ConfigurationNameCriterion
+     *
+     * Match activations whose configurationName equals any of the specified
+     * values (exact match, OR semantics).
+     */
+    message ConfigurationNameCriterion {
+      repeated string values = 1;
+    }
+
+    /*
+     * ClientActivationIdCriterion
+     *
+     * Match activations by client-supplied activation ID (exact match, OR semantics).
+     */
+    message ClientActivationIdCriterion {
+      repeated string values = 1;
+    }
+
+    /*
+     * CategoryCriterion
+     *
+     * Match activations whose configuration belongs to any of the specified
+     * categories (exact match, OR semantics).
+     */
+    message CategoryCriterion {
+      repeated string values = 1;
+    }
+
+    /*
+     * TagsCriterion
+     *
+     * Match activations that have any of the specified tags.  Multiple tags
+     * within a single TagsCriterion are ORed; use separate TagsCriterion
+     * entries in the outer criteria list (ANDed) to require multiple tags
+     * simultaneously.
+     */
+    message TagsCriterion {
+      repeated string values = 1;
+    }
+
+    /*
+     * AttributesCriterion
+     *
+     * Match activations by attribute key and optional value(s).
+     * key (maps to Attribute.name) is required.
+     * values is optional: if non-empty, the activation must have the key with
+     * one of the specified values (OR); if empty, any activation possessing
+     * the key matches regardless of value (key-only / existence search).
+     */
+    message AttributesCriterion {
+      string key = 1;             // required; matches Attribute.name
+      repeated string values = 2; // optional; empty list = key-only search
+    }
+  }
+}
+
+/*
+ * QueryConfigurationActivationsResponse
+ *
+ * Contains the results of a queryConfigurationActivations() request.  Payload
+ * is an ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a QueryConfigurationActivationsResult with the matching records.
+ *
+ * An empty query result is returned as a QueryConfigurationActivationsResult with
+ * an empty configurationActivations list (not an ExceptionalResult).
+ */
+message QueryConfigurationActivationsResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    QueryConfigurationActivationsResult queryConfigurationActivationsResult = 11;
+  }
+
+  /*
+   * QueryConfigurationActivationsResult
+   *
+   * Contains a page of ConfigurationActivation records matching the query criteria.
+   *
+   * nextPageToken is non-empty when additional pages are available; supply it
+   * as pageToken in the next request to retrieve the following page.
+   * An empty nextPageToken indicates the last page.
+   */
+  message QueryConfigurationActivationsResult {
+    repeated dp.service.common.ConfigurationActivation configurationActivations = 1;
+    string nextPageToken = 2;
+  }
+}
+
+
+//
+// ------------------- Configuration Activation Delete / Patch / BulkSave ---------------------------
+//
+
+/*
+ * DeleteConfigurationActivationRequest
+ *
+ * Delete a ConfigurationActivation record by clientActivationId or composite
+ * key (configurationName + startTime).  Exactly one key must be set.
+ */
+message DeleteConfigurationActivationRequest {
+
+  oneof key {
+    string clientActivationId = 1;
+    CompositeKey compositeKey = 2;
+  }
+
+  /*
+   * CompositeKey
+   *
+   * Identifies a ConfigurationActivation by configurationName and startTime
+   * when clientActivationId is not available.
+   */
+  message CompositeKey {
+    string configurationName = 1;
+    dp.service.common.Timestamp startTime = 2;
+  }
+}
+
+/*
+ * DeleteConfigurationActivationResponse
+ *
+ * Contains the result of a deleteConfigurationActivation() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a DeleteConfigurationActivationResult.
+ */
+message DeleteConfigurationActivationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    DeleteConfigurationActivationResult deleteConfigurationActivationResult = 11;
+  }
+
+  /*
+   * DeleteConfigurationActivationResult
+   *
+   * Contains the result of a successful deleteConfigurationActivation() request.
+   */
+  message DeleteConfigurationActivationResult {
+    string clientActivationId = 1; // ID of the deleted activation record
+  }
+}
+
+/*
+ * PatchConfigurationActivationRequest
+ *
+ * Partial update of an existing ConfigurationActivation record.
+ *
+ * NOT YET IMPLEMENTED.  The patch fields and field mask mechanism are deferred
+ * to the release that implements patchConfigurationActivation().  This message
+ * is defined now to reserve the name and establish the pattern.
+ */
+message PatchConfigurationActivationRequest {
+  string clientActivationId = 1; // required
+}
+
+/*
+ * PatchConfigurationActivationResponse
+ *
+ * Contains the result of a patchConfigurationActivation() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a PatchConfigurationActivationResult.
+ */
+message PatchConfigurationActivationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    PatchConfigurationActivationResult patchConfigurationActivationResult = 11;
+  }
+
+  /*
+   * PatchConfigurationActivationResult
+   *
+   * Contains the result of a successful patchConfigurationActivation() request.
+   */
+  message PatchConfigurationActivationResult {
+    string clientActivationId = 1; // ID of the updated activation record
+  }
+}
+
+/*
+ * BulkSaveConfigurationActivationRequest
+ *
+ * Bulk create or replace multiple ConfigurationActivation records in a single
+ * request.  Each record uses the same full-replace upsert semantics as
+ * saveConfigurationActivation().  Intended for bulk loading of activation
+ * records from operational calendars.
+ *
+ * NOT YET IMPLEMENTED.  This message is defined now to reserve the name and
+ * establish the pattern for bulk-write operations in this service.
+ */
+message BulkSaveConfigurationActivationRequest {
+  repeated SaveConfigurationActivationRequest requests = 1;
+}
+
+/*
+ * BulkSaveConfigurationActivationResponse
+ *
+ * Contains the result of a bulkSaveConfigurationActivation() request.  Payload
+ * is an ExceptionalResult if the entire request is rejected (e.g. validation
+ * failure before any records are processed), otherwise contains a
+ * BulkSaveConfigurationActivationResult reporting the count of successfully
+ * saved records and per-item details for any failures.
+ *
+ * A response with BulkSaveConfigurationActivationResult and a non-empty errors
+ * list indicates a partial failure: some records were saved and some were not.
+ */
+message BulkSaveConfigurationActivationResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    BulkSaveConfigurationActivationResult bulkSaveConfigurationActivationResult = 11;
+  }
+
+  /*
+   * BulkSaveConfigurationActivationResult
+   *
+   * savedCount is the number of records successfully saved.
+   * errors contains one entry per failed record; an empty list means all
+   * records were saved successfully.
+   */
+  message BulkSaveConfigurationActivationResult {
+
+    uint32 savedCount = 1;
+    repeated BulkSaveError errors = 2;
+
+    /*
+     * BulkSaveError
+     *
+     * Describes a failure for a single record within a bulk save request.
+     */
+    message BulkSaveError {
+      string clientActivationId = 1;
+      dp.service.common.ExceptionalResult exceptionalResult = 2;
+    }
+  }
+}
+
+
+//
+// ------------------- Get Active Configurations Request/Response ---------------------------
+//
+
+/*
+ * GetActiveConfigurationsRequest
+ *
+ * Returns all ConfigurationActivation records in effect at the specified
+ * timestamp, i.e., records where:
+ *   startTime <= timestamp AND (endTime is absent OR endTime > timestamp)
+ *
+ * timestamp is required.  Requests with an absent (zero-value) timestamp are
+ * rejected with an ExceptionalResult.
+ */
+message GetActiveConfigurationsRequest {
+  dp.service.common.Timestamp timestamp = 1; // required point in time
+}
+
+/*
+ * GetActiveConfigurationsResponse
+ *
+ * Contains the result of a getActiveConfigurations() request.  Payload is an
+ * ExceptionalResult if the request is rejected or an error is encountered,
+ * otherwise contains a GetActiveConfigurationsResult.
+ *
+ * An empty result (no active configurations at the specified time) is returned
+ * as a GetActiveConfigurationsResult with an empty configurationActivations
+ * list (not an ExceptionalResult).
+ */
+message GetActiveConfigurationsResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    GetActiveConfigurationsResult getActiveConfigurationsResult = 11;
+  }
+
+  /*
+   * GetActiveConfigurationsResult
+   *
+   * Contains the list of ConfigurationActivation records in effect at the
+   * requested timestamp.
+   */
+  message GetActiveConfigurationsResult {
+    repeated dp.service.common.ConfigurationActivation configurationActivations = 1;
   }
 }

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -80,6 +80,68 @@ message PvMetadata {
   string description = 8; // optional free-text description
 }
 
+/*
+ * Configuration
+ *
+ * Reusable machine configuration definition. configurationName is the canonical
+ * identifier — no pre-registration is required.
+ *
+ * Placed in common.proto so it can be referenced by any service (annotation,
+ * query, etc.) without introducing cross-service import cycles.
+ *
+ * createdTime / updatedTime are server-set audit timestamps.
+ *
+ * modifiedBy is an unvalidated free-form string identifying the actor (user,
+ * service, or system) that performed the most recent save.  It reflects only
+ * the last writer; no history is maintained.
+ */
+message Configuration {
+
+  string configurationName = 1;       // canonical identifier (required)
+  string category = 2;                // required
+  string description = 3;             // optional free-text description
+  string parentConfigurationName = 4; // optional parent configuration name
+  repeated string tags = 5;           // optional keyword tags (normalized to lowercase unique set)
+  repeated Attribute attributes = 6;  // optional key/value attribute pairs
+  Timestamp createdTime = 7;          // server-set: time record was first created
+  Timestamp updatedTime = 8;          // server-set: time record was most recently saved
+  string modifiedBy = 9;              // optional actor / user / service identity for last save
+}
+
+/*
+ * ConfigurationActivation
+ *
+ * Represents the time interval during which a Configuration was active.
+ * startTime is required; endTime is optional (absent = open-ended interval).
+ *
+ * clientActivationId is an optional client-supplied stable identifier (e.g., a
+ * calendar event ID).  If omitted, the server generates an opaque identifier.
+ * Clients loading activations from external systems should always supply
+ * clientActivationId to enable future updates without a prior lookup.
+ *
+ * Placed in common.proto so it can be referenced by any service (annotation,
+ * query, etc.) without introducing cross-service import cycles.
+ *
+ * createdTime / updatedTime are server-set audit timestamps.
+ *
+ * modifiedBy is an unvalidated free-form string identifying the actor (user,
+ * service, or system) that performed the most recent save.  It reflects only
+ * the last writer; no history is maintained.
+ */
+message ConfigurationActivation {
+
+  string clientActivationId = 1;      // optional client-supplied primary key; server-generated if absent
+  string configurationName = 2;       // required; references a Configuration record
+  Timestamp startTime = 3;            // required
+  Timestamp endTime = 4;              // optional; absent = open-ended interval
+  string description = 5;             // optional free-text description
+  repeated string tags = 6;           // optional keyword tags (normalized to lowercase unique set)
+  repeated Attribute attributes = 7;  // optional key/value attribute pairs
+  Timestamp createdTime = 8;          // server-set: time record was first created
+  Timestamp updatedTime = 9;          // server-set: time record was most recently saved
+  string modifiedBy = 10;             // optional actor / user / service identity for last save
+}
+
 //
 // ------------------- Time Definitions ---------------------------
 //


### PR DESCRIPTION
# dp-grpc #120: Proto changes for Machine Configuration API

## Summary

Adds a new **Machine Configuration API** to `DpAnnotationService` that provides a mechanism
for describing the operational state of the accelerator at a given point in time. This
metadata helps users interpret associated PV time-series data — for example, identifying
which machine mode was active during a beam loss event, or comparing orbit data across
different energy configurations.

The API separates two related concepts:

- **Configuration** — a reusable named definition of a machine mode or state (e.g., `TopOff`,
  `3GeV`, `UserOps`), belonging to a category, with optional parent hierarchy, tags, and
  attributes.
- **ConfigurationActivation** — a time interval during which a Configuration was active,
  supporting both live recording and retroactive loading from operational calendars.

## Changes

### `common.proto`

Two new shared messages, placed in `common.proto` so they can be referenced by any service
(annotation, query, etc.) without import cycles:

- **`Configuration`** — canonical machine configuration definition, keyed by
  `configurationName`.
- **`ConfigurationActivation`** — activation interval record, with an optional
  client-supplied `clientActivationId` (e.g., a calendar event ID) for stable external
  referencing, and `startTime` / `endTime` for the active interval (open-ended if `endTime`
  is absent).

### `annotation.proto`

Thirteen new RPC methods added to `DpAnnotationService`, with full request/response messages:

**Configuration definition CRUD:**
| Method | Status |
|---|---|
| `saveConfiguration` | Implemented |
| `getConfiguration` | Implemented |
| `queryConfigurations` | Implemented |
| `deleteConfiguration` | Implemented |
| `patchConfiguration` | Deferred stub (NOT YET IMPLEMENTED) |
| `bulkSaveConfiguration` | Deferred stub (NOT YET IMPLEMENTED) |

**Configuration activation CRUD:**
| Method | Status |
|---|---|
| `saveConfigurationActivation` | Implemented |
| `getConfigurationActivation` | Implemented |
| `queryConfigurationActivations` | Implemented |
| `deleteConfigurationActivation` | Implemented |
| `patchConfigurationActivation` | Deferred stub (NOT YET IMPLEMENTED) |
| `bulkSaveConfigurationActivation` | Deferred stub (NOT YET IMPLEMENTED) |

**Active configuration query:**
| Method | Status |
|---|---|
| `getActiveConfigurations` | Implemented |

## Key Design Decisions

- **`configurationName`** is the canonical identifier for Configuration records — no
  pre-registration with UUIDs required.
- **`clientActivationId`** is an optional client-supplied stable identifier for activation
  records (e.g., a calendar event ID). The server generates an opaque ID if omitted.
  Clients loading activations from external calendars should always supply this field.
- **`get*` / `delete*` for activations** accept either `clientActivationId` or a composite
  key `(configurationName, startTime)` via a `oneof key`.
- **`saveConfigurationActivation`** uses full-replace upsert semantics — closing an
  open-ended activation is done by calling `saveConfigurationActivation` with `endTime` set,
  with no separate `deactivate` method needed.
- **Category overlap enforcement** — the server rejects overlapping activations for the same
  `configurationName` or within the same category. Category is not exposed on
  `ConfigurationActivation` in the API; the server derives and stores it internally.
- **`getActiveConfigurations`** requires an explicit `timestamp`; a zero-value timestamp is
  rejected.
- **`queryConfigurationActivations`** supports both a `TimestampCriterion` (active at a
  point) and a `TimeRangeCriterion` (overlapping a window), consistent with time-series
  query semantics used elsewhere in MLDP.
- **`patch*` and `bulkSave*`** methods are declared as deferred stubs following the
  established CRUD pattern for metadata APIs in this service.
- Follows all naming and structural conventions of the PV Metadata API (PR #117): `criteria`
  / `Criterion` naming, `AttributesCriterion` with empty `values` for key-only search,
  full-replace warnings on `save*` requests, `responseTime` + `oneof result` response
  pattern, and pagination via `limit` / `pageToken` / `nextPageToken`.

## Use Cases Enabled

- What machine mode was active during beam loss?
- Compare orbit data during `TopOff` vs `UserOps`.
- Which energy configuration was active during this archive interval?
- Find all data collected during a vacuum recovery study.
- Bulk-load a month of machine configuration history from an operational calendar.
