### PR TITLE
dp-grpc #123: Query API V2 definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Data is stored and transmitted in **column-oriented** vectors, one column per PV
 - **Scalar**: `DoubleColumn`, `FloatColumn`, `Int64Column`, `Int32Column`, `BoolColumn`, `StringColumn`, `EnumColumn`
 - **Array**: `DoubleArrayColumn`, `FloatArrayColumn`, `Int64ArrayColumn`, `Int32ArrayColumn`, `BoolArrayColumn`
 - **Complex**: `ImageColumn`, `StructColumn`, `SerializedDataColumn`
-- **Deprecated**: `DataColumn` / `DataValue` (per-sample allocation; avoid for new ingestion)
+- **Deprecated for ingestion only**: `DataColumn` / `DataValue` (per-sample allocation; avoid for new ingestion). Still the supported representation for tabular/sample query results (e.g. the Query V2 `ColumnTable`) and Annotation Calculations, where an unset `DataValue` oneof provides missing-value support the dense types lack.
 
 Each column message carries an optional `ColumnMetadata metadata = 10` field (added in issue #116) containing `ColumnProvenance` (source/process), `tags`, and `attributes`.
 
@@ -62,6 +62,9 @@ Two modes:
 - `SamplingClock` — start time + period (nanos) + count (uniform sampling)
 - `TimestampList` — explicit list of `Timestamp` messages
 
+### TimeRange (`common.proto`)
+Shared query time interval (added in issue #123 for Query API V2): `beginTime`, `endTime`. Half-open `[beginTime, endTime)` at the sample axis; bucket selection is an overlap test (`bucket.firstTime < endTime AND bucket.lastTime >= beginTime`).
+
 ### Bucket Pattern
 Ingestion and storage use the [MongoDB bucket pattern](https://www.mongodb.com/blog/post/building-with-patterns-the-bucket-pattern): all sample values for a PV over a time range are stored as a single record, not one record per sample.
 
@@ -80,10 +83,16 @@ All response messages use a `oneof result` with either `ExceptionalResult` (reje
 - `queryRequestStatus` — check async ingestion request outcomes
 
 ### DpQueryService (`query.proto`)
+
+V1 (retained for backward compatibility):
 - `queryData` / `queryDataStream` / `queryDataBidiStream` / `queryTable` — retrieve archived time-series data
-- `queryPvMetadata` — PV archive metadata (first/last timestamp, data type, bucket stats)
+- `queryPvStats` — PV archive statistics (first/last timestamp, data type, bucket stats)
 - `queryProviders` — find providers by id, text, tags, attributes
-- `queryProviderMetadata` — ingestion statistics for a provider
+- `queryProviderStats` — ingestion statistics for a provider
+
+V2 (added in issue #123): a common `QuerySpec` (time range + `PvSelector` [name list / regex / metadata criteria] + `ConfigurationSelector`) is bundled with `ExecutionOptions` (paging: `limit`/`pageToken`) and `ResultRepresentation` (format flags) in each request. `QuerySpec` field 4 reserves a future `sampleStatusSelector`.
+- `queryBuckets` / `queryBucketsStream` — bucket-oriented; returns `DataBucket` objects, boundary buckets whole. Unary is resumable/paged; streaming is fire-and-consume (chunked, no continuation tokens).
+- `querySamples` / `querySamplesStream` — sample-oriented; returns an aligned column-oriented `ColumnTable` (union timestamp axis, samples trimmed to `[beginTime, endTime)`, missing values via unset `DataValue`). Preferred for Python/analysis.
 
 ### DpAnnotationService (`annotation.proto`)
 - `savePvMetadata` / `queryPvMetadata` / `getPvMetadata` / `deletePvMetadata` — PV metadata CRUD (`patchPvMetadata` / `bulkSavePvMetadata` deferred stubs)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The main objective of the Ingestion Service API is to provide a streamlined high
 
 The core feature of the Query Service API is retrieval of PV time-series data over a range of time.  There are both unary and streaming query methods, with results that contain either bucketed or tabular data.  Methods are also provided for querying archive ingestion statistics for PVs and data providers.
 
+A second generation of the time-series query API (Query API V2) is also provided (see [PV data query V2 methods](#pv-data-query-v2-methods)).  V2 introduces a common `QuerySpec` shared by all query methods that describes *what* data to retrieve — time range, PV selection (explicit list, name pattern, or PV metadata criteria), and machine-configuration filtering — independently of *how* results are returned.  Bucket-oriented methods return the archive's native `DataBucket` objects, while sample-oriented methods return an aligned, column-oriented table suited to Python and analysis workflows.  The original V1 query methods remain available for backward compatibility.
+
 ### Annotation Service API
 
 The Annotation Service API provides tools for augmenting the PV time-series data archive with facility-specific information.  The core feature is identifying datasets, each containing blocks of data defined by a list of PVs and a range of time, and adding annotations to those datasets.  An annotation includes descriptive elements like freeform text comment, keywords, and key-value attributes, and may also include user-defined calculations that use links for tracking data provenance.  The API also includes tools for exporting datasets and calculations to common file formats including HDF5, CSV, and XLSX.  A PV metadata API is provided for associating user-defined metadata (aliases, tags, attributes, description) with PVs and using that metadata to discover PVs of interest.  A machine configuration API is also provided for recording and querying the operational state of the accelerator at a point in time, including reusable configuration definitions (e.g., `TopOff`, `3GeV`, `UserOps`) and time-stamped activation intervals that can be loaded from operational calendars or recorded in real time.
@@ -87,7 +89,7 @@ The table below gives an overview of the Data Platform API organized by service.
 | Service          | API Methods                                                                                                                                                                                                                                                                                                                                                                                                                              |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Ingestion        | [Provider&nbsp;registration](#provider-registration-methods)<br>[PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Request&nbsp;Status&nbsp;query](#request-status-query-methods)<br>                                                                                                                                                                      |
-| Query            | [PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;stats&nbsp;query](#provider-stats-query-methods)<br>                                                                                                                                                                                                        |
+| Query            | [PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;data&nbsp;query&nbsp;V2](#pv-data-query-v2-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;stats&nbsp;query](#provider-stats-query-methods)<br>                                                                                                                                                                                                        |
 | Annotation       | [PV&nbsp;metadata&nbsp;save](#pv-metadata-save-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[PV&nbsp;metadata&nbsp;get](#pv-metadata-get-methods)<br>[PV&nbsp;metadata&nbsp;delete](#pv-metadata-delete-methods)<br>[Configuration&nbsp;save](#configuration-save-methods)<br>[Configuration&nbsp;query](#configuration-query-methods)<br>[Configuration&nbsp;Activation&nbsp;save](#configuration-activation-save-methods)<br>[Configuration&nbsp;Activation&nbsp;query](#configuration-activation-query-methods)<br>[Data&nbsp;Set&nbsp;save](#data-set-save-methods)<br>[Data&nbsp;Set&nbsp;query](#data-set-query-methods)<br>[Data&nbsp;export](#data-export-methods)<br>[Annotation&nbsp;save](#annotation-save-methods)<br>[Annotation&nbsp;query](#annotation-query-methods)<br> |
 | Ingestion Stream | [Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>                                                                                                                                                                                                                                                                                                                                                             |
 
@@ -99,7 +101,7 @@ The table below gives an overview of the Data Platform API organized by entity. 
 | Entity   | Description | API Methods                                                                                                                                                                                                                                                                                                                                                                         |
 |----------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Provider | An infrastructure component that sends correlated PV time-series data to the archive.  Might be associated with an EPICS IOC. | [Provider&nbsp;registration](#provider-registration-methods)<br>[Provider&nbsp;query](#provider-query-methods)<br>[Provider&nbsp;stats&nbsp;query](#provider-stats-query-methods)<br>                                                                                                                                         |
-| PV Time-Series Data | The core of the MLDP archive is correlated PV time-series data captured from devices in an accelerator facility. | [PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>      |
+| PV Time-Series Data | The core of the MLDP archive is correlated PV time-series data captured from devices in an accelerator facility. | [PV&nbsp;data&nbsp;ingestion](#pv-data-ingestion-methods)<br>[PV&nbsp;data&nbsp;query](#pv-data-query-methods)<br>[PV&nbsp;data&nbsp;query&nbsp;V2](#pv-data-query-v2-methods)<br>[PV&nbsp;data&nbsp;subscription](#pv-data-subscription-methods)<br>[Data&nbsp;Event&nbsp;subscription](#pv-data-event-subscription-methods)<br>[PV&nbsp;stats&nbsp;query](#pv-stats-query-methods)<br>      |
 | PV Metadata | User-defined metadata associated with a PV, including aliases, tags, key-value attributes, and description.  Used to discover and identify PVs of interest. | [PV&nbsp;metadata&nbsp;save](#pv-metadata-save-methods)<br>[PV&nbsp;metadata&nbsp;query](#pv-metadata-query-methods)<br>[PV&nbsp;metadata&nbsp;get](#pv-metadata-get-methods)<br>[PV&nbsp;metadata&nbsp;delete](#pv-metadata-delete-methods)<br>                                                                               |
 | Ingestion Request Status | Data ingestion requests are handled asynchronously to maximize performance, so the disposition of individual requests is recorded in a Request Status record. | [Request&nbsp;Status&nbsp;query](#request-status-query-methods)<br>                                                                                                                                                                                                                                                            |
 | Machine Configuration | A reusable named definition of a machine mode or operational state (e.g., `TopOff`, `3GeV`, `UserOps`), belonging to a category, with optional parent hierarchy, tags, and attributes.  Used to describe the accelerator state for interpretation of associated PV data. | [Configuration&nbsp;save](#configuration-save-methods)<br>[Configuration&nbsp;query](#configuration-query-methods)<br>                                                                                                                                                                                    |
@@ -379,6 +381,44 @@ A TableResult message contains a list of PV column data vectors, one for each PV
 ----
 
 The response message for the unary methods cannot exceed the maximum gRPC message size limit, or an error is returned by the methods.
+</td>
+</tr>
+</table>
+
+### PV Data Query V2 Methods
+<table>
+<tr>
+<td><pre>
+rpc queryBuckets(QueryBucketsRequest) returns (QueryBucketsResponse);
+rpc queryBucketsStream(QueryBucketsRequest) returns (stream QueryBucketsResponse);
+rpc querySamples(QuerySamplesRequest) returns (QuerySamplesResponse);
+rpc querySamplesStream(QuerySamplesRequest) returns (stream QuerySamplesResponse);
+</pre></td>
+</tr>
+<tr>
+<td>defined in: query.proto</td>
+</tr>
+<tr>
+<td>
+Query API V2 provides a second generation of the time-series data query API.  Its central abstraction is a common QuerySpec, shared by all four methods, that describes <em>what</em> data to retrieve independently of <em>how</em> results are represented.  The original V1 query methods (above) remain available for backward compatibility.
+
+Each request bundles three messages: a QuerySpec (the logical query), an optional ExecutionOptions (paging), and an optional ResultRepresentation (result format flags).
+
+A QuerySpec contains a TimeRange (half-open [beginTime, endTime)), a PvSelector, and an optional ConfigurationSelector.  The PvSelector selects PVs by one of an explicit name list, a name regex pattern, or PV metadata criteria (mirroring the PV Metadata query language).  The ConfigurationSelector restricts returned data to intervals during which matching machine configurations were active, by intersecting the matching activations' intervals with the query TimeRange.  A reserved field is set aside in QuerySpec for a future sample-status selector.
+
+ExecutionOptions carries a limit and an opaque pageToken, following the common MLDP paging model (an empty nextPageToken in the response indicates the last page).  ResultRepresentation carries flags controlling whether column metadata is excluded and whether serialized columns are used.
+
+----
+
+The two bucket-oriented methods return QueryBucketsResponse messages containing a BucketQueryResult with a list of DataBucket objects that closely match the archive storage model.  Boundary buckets are returned whole, so the first and last buckets may contain samples outside the requested time range.  These methods are intended for Java applications, archive export, and high-performance retrieval.
+
+The two sample-oriented methods return QuerySamplesResponse messages containing a SampleQueryResult with a ColumnTable.  The service assembles buckets internally into a continuous, aligned, column-oriented table over a single union timestamp axis, trimming samples to the half-open time range; where a PV has no sample at a given timestamp the value is left unset (missing).  These methods are intended for Python, Pandas/NumPy/Polars, machine learning, and visualization use cases.
+
+For both styles, the unary methods (queryBuckets, querySamples) provide resumable, bounded-memory paging via the pageToken.  The streaming methods (queryBucketsStream, querySamplesStream) are fire-and-consume: the server streams to completion using limit as the per-message chunk size, and does not emit continuation tokens.
+
+----
+
+As with the V1 methods, an ExceptionalResult is returned on rejection or error; an empty query result is returned as an empty result payload rather than an ExceptionalResult.
 </td>
 </tr>
 </table>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ospreydcs</groupId>
     <artifactId>dp-grpc</artifactId>
     <packaging>jar</packaging>
-    <version>1.14.0</version>
+    <version>1.15.0</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -198,6 +198,29 @@ message DataTimestamps {
   }
 }
 
+/*
+ * TimeRange
+ *
+ * Specifies a time interval over which data should be retrieved.  Placed in
+ * common.proto because intervals are referenced across query and other use
+ * cases.
+ *
+ * Interval semantics are half-open [beginTime, endTime) at the sample axis,
+ * matching the MLDP bucket query engine.  Bucket selection is an interval-overlap
+ * test: a bucket is selected iff
+ *
+ *   bucket.firstTime <  endTime   AND   bucket.lastTime >= beginTime
+ *
+ * so a selected boundary bucket may contain individual samples outside
+ * [beginTime, endTime).  How those edge samples are handled differs by query
+ * method (bucket queries return boundary buckets whole; sample queries trim to
+ * the range).
+ */
+message TimeRange {
+  Timestamp beginTime = 1; // Required, inclusive start of interval.
+  Timestamp endTime = 2;   // Required, exclusive end of interval.
+}
+
 
 //
 // ------------------- Common Result Definitions ---------------------------
@@ -447,6 +470,10 @@ message SerializedDataColumn {
  * DataColumns in ingestion causes per-sample memory allocation that is inefficient. Data values are stored in the
  * database as a single opaque blob, even for scalar-valued columns. Consider using one of the above column-oriented
  * data structures for ingestion efficiency.
+ *
+ * This deprecation applies to ingestion only. DataColumn remains the supported representation for tabular/sample
+ * query results (e.g. the Query V2 ColumnTable) and for Annotation Calculations, where an unset DataValue value
+ * oneof provides native missing-value support that the dense column-oriented types do not.
  *
  */
 message DataColumn {

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -117,6 +117,426 @@ service DpQueryService {
    */
   rpc queryProviderStats(QueryProviderStatsRequest) returns (QueryProviderStatsResponse);
 
+
+  //
+  // ------------------- Query API V2 methods ---------------------------
+  //
+  // Query API V2 introduces a common QuerySpec shared by all methods below.
+  // QuerySpec describes WHAT data to retrieve (time range, PV selection,
+  // configuration filtering) independently of HOW results are represented.
+  // Each request bundles a QuerySpec with optional ExecutionOptions (paging) and
+  // ResultRepresentation (format flags).  V1 methods above remain available for
+  // backward compatibility.
+  //
+
+  /*
+   * queryBuckets(): Unary bucket-oriented time-series query (V2).
+   *
+   * Executes the supplied QuerySpec and returns one page of DataBucket objects,
+   * each corresponding closely to the underlying archive storage model.
+   * Additional pages are retrieved by resubmitting the same QuerySpec with the
+   * nextPageToken from the previous response placed in ExecutionOptions.pageToken.
+   *
+   * Boundary buckets are returned WHOLE (not trimmed): a bucket overlapping the
+   * TimeRange is returned intact, so its first/last bucket may contain individual
+   * samples outside [beginTime, endTime).  Callers wanting samples strictly
+   * within the range should use querySamples(), which trims.
+   *
+   * Intended for Java applications, archive export, infrastructure services, and
+   * high-performance retrieval.
+   */
+  rpc queryBuckets(QueryBucketsRequest) returns (QueryBucketsResponse);
+
+  /*
+   * queryBucketsStream(): Server-streaming bucket-oriented query (V2).
+   *
+   * Executes the supplied QuerySpec and streams QueryBucketsResponse messages
+   * until the result is exhausted, the client cancels, or an error occurs.
+   * Replaces the V1 bidirectional cursor protocol; the client is not responsible
+   * for advancing server-side cursors.
+   *
+   * Paging semantics for streaming: ExecutionOptions.limit controls the chunk
+   * size of each streamed response.  Streaming is fire-and-consume — the server
+   * streams to completion and does not emit continuation tokens (nextPageToken is
+   * empty); ExecutionOptions.pageToken is ignored.  Use unary queryBuckets() when
+   * resumable paging is required.
+   */
+  rpc queryBucketsStream(QueryBucketsRequest) returns (stream QueryBucketsResponse);
+
+  /*
+   * querySamples(): Unary sample-oriented time-series query (V2).
+   *
+   * Executes the supplied QuerySpec and returns one page of aligned sample data
+   * as a column-oriented table.  The server assembles bucket data internally to
+   * present a continuous view of the requested interval; bucket boundaries are
+   * hidden from the client.
+   *
+   * Samples are TRIMMED to the half-open TimeRange [beginTime, endTime): the
+   * server retrieves overlapping buckets and drops edge samples that fall outside
+   * the range, so every returned timestamp satisfies beginTime <= t < endTime.
+   * (This carries forward the trimming behavior of the V1 queryTable processor.)
+   *
+   * Expected to become the preferred method for the Python client library,
+   * interactive analysis, data science, machine learning, and visualization.
+   */
+  rpc querySamples(QuerySamplesRequest) returns (QuerySamplesResponse);
+
+  /*
+   * querySamplesStream(): Server-streaming sample-oriented query (V2).
+   *
+   * Streams aligned sample data as successive ColumnTable pages.  Paging
+   * semantics match queryBucketsStream(): ExecutionOptions.limit controls the
+   * number of timestamps (rows) per streamed response; streaming is
+   * fire-and-consume (no continuation tokens; ExecutionOptions.pageToken
+   * ignored).  Use unary querySamples() when resumable paging is required.
+   */
+  rpc querySamplesStream(QuerySamplesRequest) returns (stream QuerySamplesResponse);
+
+}
+
+
+//
+// ------------------- Query API V2 Shared Query Model ---------------------------
+//
+
+/*
+ * QuerySpec
+ *
+ * Describes the logical time-series query — the "WHERE" clause — independently
+ * of paging and result representation.  The same QuerySpec may be executed by
+ * any V2 query method.
+ *
+ * Supports timeRange (required), pvSelector (required), and the optional
+ * configurationSelector.
+ *
+ * Field 4 is reserved for a future sampleStatusSelector, to be defined once the
+ * Sample Status API is settled.  Its shape is intentionally not committed here.
+ */
+message QuerySpec {
+
+  dp.service.common.TimeRange timeRange = 1; // Required, query time interval.
+
+  PvSelector pvSelector = 2; // Required, selects which PVs to include.
+
+  // Optional, restrict to periods when matching configurations were active.
+  ConfigurationSelector configurationSelector = 3;
+
+  // Reserved for a future sample-status selector (Sample Status API).
+  // The selector shape will be defined against that API when implemented.
+  reserved 4;
+  reserved "sampleStatusSelector";
+}
+
+/*
+ * PvSelector
+ *
+ * Selects which PVs are included in a query.  Exactly one selector must be set;
+ * an unset PvSelector (or an unset selector oneof) returns an ExceptionalResult.
+ */
+message PvSelector {
+
+  oneof selector {
+    PvNameList pvNameList = 1;       // Explicit PV name list.
+    PvNamePattern pvNamePattern = 2; // Regex over PV names.
+    MetadataQuery metadataQuery = 3; // PV metadata criteria (mirrors queryPvMetadata).
+  }
+
+  /*
+   * MetadataQuery
+   *
+   * Selects PVs by metadata, mirroring the query language of
+   * DpAnnotationService.queryPvMetadata().  Multiple criteria are ANDed; values
+   * within a criterion are ORed.  The criterion shape intentionally duplicates
+   * QueryPvMetadataRequest.QueryPvMetadataCriterion rather than sharing a type,
+   * so each stays self-documenting in its own context.
+   */
+  message MetadataQuery {
+
+    repeated Criterion criteria = 1;
+
+    /*
+     * A single PV-metadata selection criterion.  Exactly one criterion must be
+     * set.
+     */
+    message Criterion {
+
+      oneof criterion {
+        PvNameCriterion pvNameCriterion = 10;         // by canonical PV name
+        TagsCriterion tagsCriterion = 11;             // by tag value(s)
+        AttributesCriterion attributesCriterion = 12; // by attribute key/value(s)
+        AliasesCriterion aliasesCriterion = 13;       // by alias
+      }
+
+      // PvNameCriterion: values across all three sub-lists are ORed.
+      message PvNameCriterion {
+        repeated string exact = 1;    // exact string match
+        repeated string prefix = 2;   // prefix match
+        repeated string contains = 3; // substring match
+      }
+
+      // TagsCriterion: tags within one criterion are ORed; separate criteria ANDed.
+      message TagsCriterion {
+        repeated string values = 1;
+      }
+
+      // AttributesCriterion: key required; empty values = key-only existence search.
+      message AttributesCriterion {
+        string key = 1;
+        repeated string values = 2;
+      }
+
+      // AliasesCriterion: mirrors PvNameCriterion; sub-lists ORed.
+      message AliasesCriterion {
+        repeated string exact = 1;
+        repeated string prefix = 2;
+        repeated string contains = 3;
+      }
+    }
+  }
+}
+
+/*
+ * ConfigurationSelector
+ *
+ * Restricts returned data to the time intervals during which matching machine
+ * configurations were active.  The server finds ConfigurationActivation records
+ * matching the supplied criteria, unions their active intervals, intersects that
+ * union with the query's TimeRange, and retrieves data only within the resulting
+ * (possibly fragmented) intervals.
+ *
+ * Criteria are NON-TEMPORAL (name, client activation id, category, tags,
+ * attributes).  Multiple criteria are ANDed; multiple values within a criterion
+ * are ORed.  Time is intentionally NOT part of the selector — the enclosing
+ * QuerySpec.timeRange is the single time axis for the whole query, so there is
+ * no second time specification to reconcile.  (These criteria mirror the
+ * non-temporal arms of annotation.proto's QueryConfigurationActivationsCriterion
+ * but are defined locally; they are not a shared type.)
+ *
+ * If no criteria are supplied, the selector matches nothing and the query
+ * returns an empty result (omit ConfigurationSelector entirely to query the full
+ * TimeRange unconditionally).
+ */
+message ConfigurationSelector {
+
+  repeated Criterion criteria = 1;
+
+  /*
+   * A single NON-TEMPORAL configuration-matching criterion, matched against the
+   * Configuration referenced by each ConfigurationActivation and the
+   * activation's own tags/attributes.  Exactly one criterion must be set.
+   */
+  message Criterion {
+
+    oneof criterion {
+      ConfigurationNameCriterion  configurationNameCriterion  = 10; // by configurationName
+      ClientActivationIdCriterion clientActivationIdCriterion = 11; // by client activation id
+      CategoryCriterion           categoryCriterion           = 12; // by category
+      TagsCriterion               tagsCriterion               = 13; // by tag value(s)
+      AttributesCriterion         attributesCriterion         = 14; // by attribute key/value(s)
+    }
+
+    // ConfigurationNameCriterion: exact configuration name(s); values ORed.
+    message ConfigurationNameCriterion {
+      repeated string values = 1;
+    }
+
+    // ClientActivationIdCriterion: exact client activation id(s); values ORed.
+    message ClientActivationIdCriterion {
+      repeated string values = 1;
+    }
+
+    // CategoryCriterion: exact category value(s); values ORed.
+    message CategoryCriterion {
+      repeated string values = 1;
+    }
+
+    // TagsCriterion: tags within one criterion ORed; separate criteria ANDed.
+    message TagsCriterion {
+      repeated string values = 1;
+    }
+
+    // AttributesCriterion: key required; empty values = key-only existence search.
+    message AttributesCriterion {
+      string key = 1;
+      repeated string values = 2;
+    }
+  }
+}
+
+/*
+ * ExecutionOptions
+ *
+ * Controls how query execution proceeds (paging).  Follows the MLDP metadata-API
+ * paging convention.
+ *
+ * Unary methods (queryBuckets / querySamples): limit is the maximum number of
+ *   result objects per page (DataBuckets for queryBuckets; timestamps/rows for
+ *   querySamples).  pageToken continues from a prior response's nextPageToken;
+ *   empty == first page.  This is the resumable, bounded-memory access path.
+ *
+ * Streaming methods (queryBucketsStream / querySamplesStream): limit is the
+ *   per-message chunk size.  Streaming is fire-and-consume: the server streams to
+ *   completion and does NOT emit continuation tokens (result nextPageToken is
+ *   empty on every streamed message).  pageToken is IGNORED on streaming calls —
+ *   the field is reserved for a possible future streaming-resume feature.  Use
+ *   the unary methods when resumability is required.
+ *
+ * If limit is omitted (0) the server selects an appropriate default.
+ */
+message ExecutionOptions {
+  uint32 limit = 1;
+  string pageToken = 2;
+}
+
+/*
+ * ResultRepresentation
+ *
+ * Controls how results are represented, without affecting which data are
+ * selected.  All fields optional.
+ */
+message ResultRepresentation {
+
+  // Include ColumnMetadata (provenance/tags/attributes) in returned columns
+  // where available.  Default behavior is to include; this flag suppresses it.
+  // (Inverted sense avoids the proto3 "default true" footgun.)
+  bool excludeColumnMetadata = 1;
+
+  // Return columns in serialized form to minimize gRPC serialization overhead.
+  // For bucket queries, each DataBucket carries a SerializedDataColumn instead of
+  // a typed column; for sample queries, ColumnTable populates serializedDataColumns
+  // instead of dataColumns.
+  bool useSerializedColumns = 2;
+}
+
+
+//
+// ------------------- Query API V2 Bucket-Oriented Query ---------------------------
+//
+
+/*
+ * QueryBucketsRequest
+ *
+ * Request for queryBuckets() and queryBucketsStream().  Carries the logical
+ * QuerySpec plus optional execution and representation options.
+ */
+message QueryBucketsRequest {
+  QuerySpec querySpec = 1;                          // Required.
+  ExecutionOptions executionOptions = 2;            // Optional.
+  ResultRepresentation resultRepresentation = 3;    // Optional.
+}
+
+/*
+ * QueryBucketsResponse
+ *
+ * Response for queryBuckets() (single message) and queryBucketsStream() (stream).
+ * Payload is an ExceptionalResult on rejection/error, otherwise a
+ * BucketQueryResult containing one page of DataBuckets.  An empty result is an
+ * empty dataBuckets list, not an ExceptionalResult.
+ */
+message QueryBucketsResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    BucketQueryResult bucketQueryResult = 11;
+  }
+
+  /*
+   * BucketQueryResult
+   *
+   * One page of DataBucket objects.  Every bucket is complete — paging
+   * boundaries always fall between buckets.  For unary queryBuckets(),
+   * nextPageToken is non-empty when more pages are available; supply it as
+   * ExecutionOptions.pageToken to continue, and an empty nextPageToken indicates
+   * the last page.  For queryBucketsStream(), nextPageToken is always empty (the
+   * stream itself signals completion).
+   */
+  message BucketQueryResult {
+    repeated dp.service.common.DataBucket dataBuckets = 1;
+    string nextPageToken = 2;
+  }
+}
+
+
+//
+// ------------------- Query API V2 Sample-Oriented Query ---------------------------
+//
+
+/*
+ * QuerySamplesRequest
+ *
+ * Request for querySamples() and querySamplesStream().  Same three-part shape as
+ * QueryBucketsRequest.  Bucket boundaries are hidden; the server assembles and
+ * aligns buckets into a continuous column-oriented table.
+ */
+message QuerySamplesRequest {
+  QuerySpec querySpec = 1;                          // Required.
+  ExecutionOptions executionOptions = 2;            // Optional.
+  ResultRepresentation resultRepresentation = 3;    // Optional.
+}
+
+/*
+ * QuerySamplesResponse
+ *
+ * Response for querySamples() (single message) and querySamplesStream() (stream).
+ * Payload is an ExceptionalResult on rejection/error, otherwise a
+ * SampleQueryResult containing one page of aligned sample data.  An empty result
+ * is an empty ColumnTable, not an ExceptionalResult.
+ */
+message QuerySamplesResponse {
+
+  dp.service.common.Timestamp responseTime = 1; // Indicates time response was generated.
+
+  oneof result {
+    dp.service.common.ExceptionalResult exceptionalResult = 10;
+    SampleQueryResult sampleQueryResult = 11;
+  }
+
+  /*
+   * SampleQueryResult
+   *
+   * One page of aligned sample data.  Paging boundaries fall between timestamps
+   * so that all PV values for a given timestamp stay together.  For unary
+   * querySamples(), nextPageToken follows the standard convention (empty == last
+   * page).  For querySamplesStream(), nextPageToken is always empty (the stream
+   * itself signals completion).
+   */
+  message SampleQueryResult {
+    ColumnTable columnTable = 1;
+    string nextPageToken = 2;
+  }
+}
+
+/*
+ * ColumnTable
+ *
+ * The sample-query result table: aligned time-series data in column-oriented
+ * form, over a single union timestamp axis.
+ *
+ * timestampList is the logical row index — the explicit, ordered union of all
+ * selected PVs' timestamps over the page.  A TimestampList (not a full
+ * DataTimestamps) is used deliberately: the union of multiple PVs' samples is in
+ * general irregular and cannot be expressed by a SamplingClock, so the sample
+ * result always carries an explicit timestamp list.
+ *
+ * Each DataColumn holds one value per timestamp; where a PV has no sample at a
+ * given timestamp, that position's DataValue has an unset value oneof (missing).
+ *
+ * V2 standardizes on this single column-oriented representation; the V1
+ * row-oriented table format is not carried forward.
+ *
+ * Columns are returned in one of two parallel forms, mirroring DataFrame in
+ * common.proto: by default the server populates dataColumns; if
+ * ResultRepresentation.useSerializedColumns is set it instead populates
+ * serializedDataColumns (the byte-encoded form of the same DataColumns, which
+ * preserves the unset-oneof missing-value encoding).  Exactly one of the two
+ * lists is populated per response.
+ */
+message ColumnTable {
+  dp.service.common.TimestampList timestampList = 1;
+  repeated dp.service.common.DataColumn dataColumns = 2;
+  repeated dp.service.common.SerializedDataColumn serializedDataColumns = 3;
 }
 
 

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -158,7 +158,8 @@ service DpQueryService {
    * Paging semantics for streaming: ExecutionOptions.limit controls the chunk
    * size of each streamed response.  Streaming is fire-and-consume — the server
    * streams to completion and does not emit continuation tokens (nextPageToken is
-   * empty); ExecutionOptions.pageToken is ignored.  Use unary queryBuckets() when
+   * empty); ExecutionOptions.pageToken must be empty (a non-empty token is
+   * rejected with an ExceptionalResult).  Use unary queryBuckets() when
    * resumable paging is required.
    */
   rpc queryBucketsStream(QueryBucketsRequest) returns (stream QueryBucketsResponse);
@@ -187,8 +188,9 @@ service DpQueryService {
    * Streams aligned sample data as successive ColumnTable pages.  Paging
    * semantics match queryBucketsStream(): ExecutionOptions.limit controls the
    * number of timestamps (rows) per streamed response; streaming is
-   * fire-and-consume (no continuation tokens; ExecutionOptions.pageToken
-   * ignored).  Use unary querySamples() when resumable paging is required.
+   * fire-and-consume (no continuation tokens; ExecutionOptions.pageToken must be
+   * empty, a non-empty token rejected with an ExceptionalResult).  Use unary
+   * querySamples() when resumable paging is required.
    */
   rpc querySamplesStream(QuerySamplesRequest) returns (stream QuerySamplesResponse);
 
@@ -238,7 +240,7 @@ message PvSelector {
   oneof selector {
     PvNameList pvNameList = 1;       // Explicit PV name list.
     PvNamePattern pvNamePattern = 2; // Regex over PV names.
-    MetadataQuery metadataQuery = 3; // PV metadata criteria (mirrors queryPvMetadata).
+    MetadataQuery metadataQuery = 3; // PV metadata criteria (mirrors DpAnnotationService.queryPvMetadata).
   }
 
   /*
@@ -309,7 +311,8 @@ message PvSelector {
  * are ORed.  Time is intentionally NOT part of the selector — the enclosing
  * QuerySpec.timeRange is the single time axis for the whole query, so there is
  * no second time specification to reconcile.  (These criteria mirror the
- * non-temporal arms of annotation.proto's QueryConfigurationActivationsCriterion
+ * non-temporal arms of annotation.proto's
+ * QueryConfigurationActivationsRequest.QueryConfigurationActivationsCriterion
  * but are defined locally; they are not a shared type.)
  *
  * If no criteria are supplied, the selector matches nothing and the query
@@ -383,9 +386,11 @@ message ConfigurationSelector {
  * Streaming methods (queryBucketsStream / querySamplesStream): limit is the
  *   per-message chunk size.  Streaming is fire-and-consume: the server streams to
  *   completion and does NOT emit continuation tokens (result nextPageToken is
- *   empty on every streamed message).  pageToken is IGNORED on streaming calls —
- *   the field is reserved for a possible future streaming-resume feature.  Use
- *   the unary methods when resumability is required.
+ *   empty on every streamed message).  pageToken must be empty on streaming
+ *   calls; a non-empty pageToken is rejected with an ExceptionalResult (rather
+ *   than silently returning the first page).  The field is reserved for a
+ *   possible future streaming-resume feature.  Use the unary methods when
+ *   resumability is required.
  *
  * If limit is omitted (0) the server selects an appropriate default.
  */

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -324,15 +324,21 @@ message ConfigurationSelector {
    * A single NON-TEMPORAL configuration-matching criterion, matched against the
    * Configuration referenced by each ConfigurationActivation and the
    * activation's own tags/attributes.  Exactly one criterion must be set.
+   *
+   * Field numbers are kept parallel to the corresponding arms of
+   * annotation.proto's QueryConfigurationActivationsCriterion (12-16).  Numbers
+   * 10-11 are intentionally omitted: in the source they are the temporal
+   * TimestampCriterion / TimeRangeCriterion arms, which have no place in a
+   * selector (QuerySpec.timeRange is the single time axis).
    */
   message Criterion {
 
     oneof criterion {
-      ConfigurationNameCriterion  configurationNameCriterion  = 10; // by configurationName
-      ClientActivationIdCriterion clientActivationIdCriterion = 11; // by client activation id
-      CategoryCriterion           categoryCriterion           = 12; // by category
-      TagsCriterion               tagsCriterion               = 13; // by tag value(s)
-      AttributesCriterion         attributesCriterion         = 14; // by attribute key/value(s)
+      ConfigurationNameCriterion  configurationNameCriterion  = 12; // by configurationName
+      ClientActivationIdCriterion clientActivationIdCriterion = 13; // by client activation id
+      CategoryCriterion           categoryCriterion           = 14; // by category
+      TagsCriterion               tagsCriterion               = 15; // by tag value(s)
+      AttributesCriterion         attributesCriterion         = 16; // by attribute key/value(s)
     }
 
     // ConfigurationNameCriterion: exact configuration name(s); values ORed.


### PR DESCRIPTION
Resolves #123.

Adds the Query API V2 definitions to `DpQueryService`, introducing a common `QuerySpec` shared by all query methods that describes *what* data to retrieve independently of *how* results are represented. The refined design and the decisions behind it are recorded in issue #123 (the original preliminary design is preserved as a comment there).

## What's added

Four new RPCs on the existing `DpQueryService` (V1 methods unchanged, retained for backward compatibility):

- `queryBuckets` / `queryBucketsStream` — bucket-oriented; returns the archive's native `DataBucket` objects, boundary buckets whole.
- `querySamples` / `querySamplesStream` — sample-oriented; returns an aligned, column-oriented `ColumnTable` over a union timestamp axis, samples trimmed to the half-open range, missing values via unset `DataValue`.

Each request bundles three messages:

- `QuerySpec` — `timeRange`, `pvSelector` (explicit list / name regex / PV metadata criteria), `configurationSelector`. Field 4 is reserved for a future `sampleStatusSelector`.
- `ExecutionOptions` — `limit` + opaque `pageToken` (common MLDP paging; empty `nextPageToken` == last page).
- `ResultRepresentation` — `excludeColumnMetadata`, `useSerializedColumns`.

Unary methods provide resumable, bounded-memory paging; streaming methods are fire-and-consume (chunked by `limit`, no continuation tokens).

## Other changes

- `common.proto`: add `TimeRange` (the only new shared type — criteria are defined locally per message, following existing conventions). Narrow the `DataColumn` deprecation note to ingestion only; it remains the representation for tabular/sample query results and Calculations.
- `pom.xml`: version 1.14.0 → 1.15.0.
- `CLAUDE.md` and `README.md`: document the V2 query API.

## Verification

- `mvn clean package` succeeds; stubs generate for all new messages/service methods (`TimeRange`, `QuerySpec`, `QueryBucketsRequest/Response`, `QuerySamplesRequest/Response`, `ColumnTable`, and the four RPC descriptors).
- V1 methods and `annotation.proto` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
