### PR TITLE
Fix generate-python-stubs workflow on rel-* tag pushes

### DIFF
--- a/.github/workflows/generate-python-stubs.yml
+++ b/.github/workflows/generate-python-stubs.yml
@@ -8,20 +8,23 @@ on:
     inputs:
       target_repo:
         description: "Target dp-python-lib repo (owner/name)"
-        required: true
-        default: "craigmcchesney/dp-python-lib"
+        required: false
+        default: "osprey-dcs/dp-python-lib"
       target_branch:
         description: "Target branch in dp-python-lib"
-        required: true
+        required: false
         default: "main"
-      dev_sync:
-        description: "Development sync (skip version bump)"
-        type: boolean
-        default: true
 
 jobs:
   generate-python-stubs:
     runs-on: ubuntu-latest
+
+    # inputs.* are only populated on workflow_dispatch; on a rel-* tag push they
+    # are empty, so every reference needs a fallback.  Without one, actions/checkout
+    # silently falls back to checking out this repo instead of dp-python-lib.
+    env:
+      TARGET_REPO: ${{ inputs.target_repo || 'osprey-dcs/dp-python-lib' }}
+      TARGET_BRANCH: ${{ inputs.target_branch || 'main' }}
 
     steps:
       # -----------------------------
@@ -87,8 +90,8 @@ jobs:
       - name: Checkout dp-python-lib
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.target_repo }}
-          ref: ${{ inputs.target_branch }}
+          repository: ${{ env.TARGET_REPO }}
+          ref: ${{ env.TARGET_BRANCH }}
           token: ${{ secrets.DP_BOT_TOKEN }}
           path: dp-python-lib
 
@@ -150,11 +153,22 @@ jobs:
       - name: Create pull request
         env:
           GH_TOKEN: ${{ secrets.DP_BOT_TOKEN }}
+          IS_RELEASE: ${{ steps.mode.outputs.release }}
+          SYNC_VERSION: ${{ steps.mode.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           cd dp-python-lib
+          BODY=$(cat <<BODY_EOF
+          Automated sync of generated Python gRPC stubs from dp-grpc.
+
+          Release: ${IS_RELEASE}
+          Version: ${SYNC_VERSION:-dev}
+          Source run: ${RUN_URL}
+          BODY_EOF
+          )
           gh pr create \
             --title "Sync Python gRPC stubs from dp-grpc" \
-            --body "Automated sync of generated Python gRPC stubs from dp-grpc.\n\nRelease: ${{ steps.mode.outputs.release }}\nVersion: ${{ steps.mode.outputs.version || 'dev' }}" \
-            --base "${{ inputs.target_branch }}" \
+            --body "$BODY" \
+            --base "${{ env.TARGET_BRANCH }}" \
             --head "$(git branch --show-current)" || echo "PR already exists"
 


### PR DESCRIPTION
Fixes #126.

The workflow triggers on both `push` (`rel-*` tags) and `workflow_dispatch`, but three steps read `${{ inputs.* }}` — only populated on `workflow_dispatch`. On a tag push those evaluate to empty, and `actions/checkout` silently falls back to checking out **this** repo instead of dp-python-lib, so the sync steps would write generated stubs into a dp-grpc checkout.

## Why this matters now

Every `push`-triggered run has failed:

| Date | Tag | Run |
|---|---|---|
| 2026-05-06 | `rel-1.14.0` | [25459278434](https://github.com/osprey-dcs/dp-grpc/actions/runs/25459278434) |
| 2026-02-27 | `rel-1.13.0` | [22503887638](https://github.com/osprey-dcs/dp-grpc/actions/runs/22503887638) |

Both failed on an empty `token:` — but `DP_BOT_TOKEN` was created 2026-07-13, *after* both runs. So that cause is already resolved, and **a tag push today would get past the token step and hit the checkout fallback instead**, failing in a much quieter way. Python stubs have never synced automatically on a release; the two successful syncs were manual dispatches.

## Changes

- **Job-level `env` with fallbacks.** `TARGET_REPO` / `TARGET_BRANCH` use `${{ inputs.x || 'default' }}`, referenced in the three places that previously read `inputs.*` directly.
- **Dispatch default repointed** from `craigmcchesney/dp-python-lib` (a fork, `isFork: true`) to `osprey-dcs/dp-python-lib` (canonical), matching the fallback. A reviewer on #125 read the old default as evidence the fork was canonical — a sign it was actively misleading.
- **Both inputs marked `required: false`**, since they now have working defaults.
- **Removed the `dev_sync` input**, declared but never referenced anywhere in the workflow.
- **PR body built with a heredoc.** The previous version used `"\n"` inside a double-quoted argument, which `gh` passes through literally rather than as newlines. Also adds a link back to the source run.

## Verification

- YAML parses; the heredoc terminator lands at column 0 after YAML block-scalar de-indentation.
- Shell logic tested in isolation: real newlines, and `${SYNC_VERSION:-dev}` correctly falls back on non-release runs.
- **Not verified end to end.** That needs a `workflow_dispatch` run with the inputs left **blank** — not merely accepting the defaults, since blank is what a tag push actually produces. Worth doing before the next release tag.

Independent of #125; no file overlap, so these can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XybUhPood4UYug3RQwQoZZ