### PR TITLE
Link to the dp-python-lib cookbook from the Python sections

### DIFF
--- a/doc/cookbook/README.md
+++ b/doc/cookbook/README.md
@@ -31,8 +31,12 @@ Roughly in the order a new client encounters them.
 
 Python users should start with **[dp-python-lib](https://github.com/osprey-dcs/dp-python-lib)**,
 a client library that wraps this API with Python-friendly request builders and result objects.
-It is the recommended way to use MLDP from Python, and its own documentation covers client
-usage.
+It is the recommended way to use MLDP from Python.
+
+Its **[cookbook](https://github.com/osprey-dcs/dp-python-lib/tree/main/doc/cookbook)** is the
+Python counterpart to this one — the same tasks, documented against that library's client classes
+rather than the raw protocol.  Recipes there cover client construction and configuration, PV
+metadata, machine configuration, and querying time-series data into pandas / NumPy.
 
 If you need to work with the generated protobuf stubs directly, see
 [Generating and importing Python stubs](python-stubs.md) for what this repo produces and how the

--- a/doc/cookbook/python-stubs.md
+++ b/doc/cookbook/python-stubs.md
@@ -6,6 +6,10 @@ from the same `.proto` files and published through
 
 > **Most Python users should not need this page.**  Install `dp-python-lib` and use its client
 > classes, which wrap the raw stubs with Python-friendly request builders and result objects.
+> Its [cookbook](https://github.com/osprey-dcs/dp-python-lib/tree/main/doc/cookbook) is the Python
+> counterpart to this one, covering client construction, PV metadata, machine configuration, and
+> querying into pandas / NumPy.
+>
 > This page is for readers who need to work with the generated protobuf modules directly, or who
 > want to understand how the stubs are produced.
 


### PR DESCRIPTION
Adds reciprocal links to the dp-python-lib cookbook from the two places here that direct Python users to that library.

Both currently say only that "its own documentation covers client usage", which predates that library having a cookbook. It now has one — a Python counterpart to this one, covering the same tasks against its client classes rather than the raw protocol — so this names it and says what is in it.

Two files, links only:

- `doc/cookbook/README.md` — the "Calling the API from Python" section
- `doc/cookbook/python-stubs.md` — the "Most Python users should not need this page" callout

Completes the ownership boundary described in [dp-python-lib#15](https://github.com/osprey-dcs/dp-python-lib/issues/15): this repo documents the protocol via Java, that repo documents its client API, and each points at the other.

## ⚠️ Merge order

**Merge this after [dp-python-lib#21](https://github.com/osprey-dcs/dp-python-lib/pull/21).**

The links point at `dp-python-lib/tree/main/doc/cookbook`, which does not exist until that PR lands. Merging this first would ship two dead links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTPUaMxTRJxScjAYhRvVFY
