### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keeps the pinned action versions current.  Without this they drift silently until an
+  # old major stops working -- the dp-service repo accumulated seven actions between one
+  # and three majors behind before anyone noticed.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci"
+    groups:
+      # One PR per month for routine bumps rather than one per action.
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/generate-python-stubs.yml
+++ b/.github/workflows/generate-python-stubs.yml
@@ -14,6 +14,11 @@ on:
         description: "Target branch in dp-python-lib"
         required: false
         default: "main"
+      dry_run:
+        description: "Generate and diff only; do not push or open a PR"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   generate-python-stubs:
@@ -25,19 +30,29 @@ jobs:
     env:
       TARGET_REPO: ${{ inputs.target_repo || 'osprey-dcs/dp-python-lib' }}
       TARGET_BRANCH: ${{ inputs.target_branch || 'main' }}
+      # A dry run generates stubs and reports what would change, but never checks out
+      # dp-python-lib, pushes, or opens a PR.  A rel-* tag push always syncs for real;
+      # a manual dispatch defaults to a dry run and must opt in to writing.  Defined
+      # once here because six separate step-level conditions would eventually drift,
+      # and the failure mode of a drifted one is an unintended write to another repo.
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
 
     steps:
       # -----------------------------
       # Checkout dp-grpc (this repo)
       # -----------------------------
       - name: Checkout dp-grpc
-        uses: actions/checkout@v4
+        # Actions are pinned to commit SHAs rather than floating major tags: this job
+        # holds DP_BOT_TOKEN, a cross-repo write credential, so a compromised upstream tag
+        # here would reach write access to dp-python-lib as well as this repo.
+        # Dependabot (.github/dependabot.yml) keeps the pins current.
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # -----------------------------
       # Python + gRPC tooling
       # -----------------------------
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -84,11 +99,18 @@ jobs:
             echo "release=false" >> $GITHUB_OUTPUT
           fi
 
+      # -----------------------------------------------------------------------------
+      # Everything below writes to dp-python-lib and is skipped on a dry run.  The
+      # checkout immediately below is the step that consumes DP_BOT_TOKEN, so a dry run
+      # never puts the cross-repo credential on disk at all.
+      # -----------------------------------------------------------------------------
+
       # -----------------------------
       # Checkout dp-python-lib
       # -----------------------------
       - name: Checkout dp-python-lib
-        uses: actions/checkout@v4
+        if: env.DRY_RUN != 'true'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ${{ env.TARGET_REPO }}
           ref: ${{ env.TARGET_BRANCH }}
@@ -99,6 +121,7 @@ jobs:
       # Sync generated stubs
       # -----------------------------
       - name: Sync Python stubs into dp-python-lib
+        if: env.DRY_RUN != 'true'
         run: |
           rm -rf dp-python-lib/src/dp_python_lib/grpc
           mkdir -p dp-python-lib/src/dp_python_lib/grpc
@@ -108,7 +131,7 @@ jobs:
       # Bump version (release only)
       # -----------------------------
       - name: Update pyproject.toml version
-        if: steps.mode.outputs.release == 'true'
+        if: env.DRY_RUN != 'true' && steps.mode.outputs.release == 'true'
         run: |
           cd dp-python-lib
           python - <<EOF
@@ -130,11 +153,13 @@ jobs:
       # -----------------------------
 
       - name: Configure git identity
+        if: env.DRY_RUN != 'true'
         run: |
           git config --global user.name "dp-grpc bot"
           git config --global user.email "dp-grpc-bot@users.noreply.github.com"
 
       - name: Commit changes
+        if: env.DRY_RUN != 'true'
         run: |
           cd dp-python-lib
           BRANCH="grpc-sync-${{ github.run_id }}"
@@ -143,6 +168,7 @@ jobs:
           git commit -m "Sync Python gRPC stubs from dp-grpc${{ steps.mode.outputs.release == 'true' && format(' rel-{0}', steps.mode.outputs.version) || '' }}" || echo "No changes to commit"
 
       - name: Push branch
+        if: env.DRY_RUN != 'true'
         run: |
           cd dp-python-lib
           git push origin HEAD
@@ -151,6 +177,7 @@ jobs:
       # Create PR (optional but recommended)
       # -----------------------------
       - name: Create pull request
+        if: env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.DP_BOT_TOKEN }}
           IS_RELEASE: ${{ steps.mode.outputs.release }}
@@ -171,4 +198,25 @@ jobs:
             --body "$BODY" \
             --base "${{ env.TARGET_BRANCH }}" \
             --head "$(git branch --show-current)" || echo "PR already exists"
+
+      # -----------------------------
+      # Dry run summary
+      # -----------------------------
+      - name: Report what a real run would sync
+        if: env.DRY_RUN == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "### Dry run — nothing was pushed"
+            echo
+            echo "Generated $(find out/python -name '*.py' | wc -l | tr -d ' ') Python files"
+            echo "that a real run would sync into \`${TARGET_REPO}\` on branch"
+            echo "\`${TARGET_BRANCH}\`."
+            echo
+            echo "Re-dispatch with \`dry_run: false\` to push a branch and open a PR."
+            echo
+            echo '```'
+            find out/python -type f -name '*.py' | sort
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/generate-python-stubs.yml
+++ b/.github/workflows/generate-python-stubs.yml
@@ -15,7 +15,7 @@ on:
         required: false
         default: "main"
       dry_run:
-        description: "Generate and diff only; do not push or open a PR"
+        description: "Generate and report only; do not push or open a PR"
         required: false
         type: boolean
         default: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to commit SHAs rather than floating major tags: this job runs
+      # with `contents: write` and publishes release artifacts, so a compromised upstream
+      # tag here could replace what users download.  Dependabot (.github/dependabot.yml)
+      # keeps the pins current.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: 21
@@ -53,7 +57,7 @@ jobs:
             > release/dp-grpc-${VERSION}.tar.gz.sha256
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             release/dp-grpc-${{ env.VERSION }}.jar


### PR DESCRIPTION
Pins all GitHub Actions references in this repo to full commit SHAs, adds a Dependabot config,
and makes `generate-python-stubs.yml` testable without writing to another repo.

Closes #133. Part of osprey-dcs/data-platform#90; follows the format settled in
osprey-dcs/dp-python-lib#34.

## Pins — 6 references, 4 distinct actions

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 |
| `actions/setup-java` | `cf277c60eb25467037889841efdb72551f06f6c3` | v4.9.1 |
| `actions/setup-python` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| `softprops/action-gh-release` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |

**No version changes.** Each floating major resolves to exactly the SHA it was replaced with
today, so nothing about what runs changes. All four actions are one major behind current
(`checkout` v4→v7, `setup-java` v4→v5, `setup-python` v5→v7, `action-gh-release` v2→v3); those
upgrades are deliberately out of scope so that any breakage here is attributable to the pinning
alone. Dependabot will propose them.

### Verification

Each SHA was resolved from its tag ref, then independently checked in the other direction —
mapping the commit back to the tags that point at it — to confirm the trailing comment is
truthful. All four resolve to both their exact semver tag and the floating major they replace.

```
grep -rnE 'uses: *[^ ]+@' .github/workflows/ | grep -vE '@[0-9a-f]{40} # v'
```

returns clean.

## Dependabot

New `.github/dependabot.yml`, copied from dp-python-lib: `github-actions` ecosystem, monthly,
`ci` commit prefix, wildcard group so routine bumps arrive as one PR rather than one per action.
Pinning trades supply-chain risk for staleness risk, and this is the other half of the trade.

## `dry_run` gate on the stub sync

`generate-python-stubs.yml` holds `DP_BOT_TOKEN`, a cross-repo write credential — it checks out
dp-python-lib, pushes a branch, and opens a PR. That makes it the higher-value workflow to pin
here, above the release path: a compromised action reaches write access to a *second* repo.

It also made the pins untestable. This repo has no CI workflow, so a PR exercises nothing, and
both workflows are `rel-*` tag-triggered. The existing `workflow_dispatch` was not a safe
rehearsal either — unlike dp-python-lib's release workflow, which gates publishing on
`event_name == 'push'`, this one had no gate at all, so a manual run wrote to dp-python-lib for
real.

So: a `dry_run` input, defaulting to `true`. A dry run generates stubs and reports what it would
have synced, but never checks out dp-python-lib, pushes, or opens a PR — the token never reaches
the runner. Dispatching with `dry_run: false` still does a real sync, so no capability is lost.
A `rel-*` tag push is unaffected and always syncs for real.

Two details worth a reviewer's eye:

- The gate is one job-level `DRY_RUN` env var, referenced by each of the six write-side steps,
  rather than six independently-written conditions. Six conditions drift, and the failure mode
  of a drifted one is an unintended write to another repo.
- `dry_run` defaults to **true**, so the destructive path requires deliberately opting in rather
  than remembering to opt out.

This was folded into this PR rather than filed separately, per discussion on #133 — it is what
makes the pins in this workflow verifiable at all.

## What this PR does and does not prove

Exercised by a dry-run dispatch against this branch: `actions/checkout` and
`actions/setup-python` — including the pinned `checkout` that a real run uses with the token.

Not exercised: `actions/setup-java` and `softprops/action-gh-release`, both in `release.yml`,
which only runs on a `rel-*` tag. Same gap dp-python-lib accepted for its two publish actions.
Both are called with unchanged inputs, so the risk is low, but it is real and unverified until
the next release.
