### PR TITLE
dp-grpc: bump version to 1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ospreydcs</groupId>
     <artifactId>dp-grpc</artifactId>
     <packaging>jar</packaging>
-    <version>1.15.0</version>
+    <version>1.16.0</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Bumps `pom.xml` to 1.16.0 for the coordinated platform release train.

No proto or code changes — this is the version bump only. Companion PRs bump dp-service and dp-desktop-app to match, and those must merge after this one so they can resolve `dp-grpc:1.16.0`.

Verified with `mvn clean install -DskipTests` (exit 0), and downstream dp-service 1.16.0 and dp-desktop-app 1.16.0 both build against the installed artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUJHS4QtFF8MwrGBresGEr