### PR TITLE
docs: correct sample status cookbook version header (1.17.0 -> 1.16.0)

### DIFF
--- a/doc/cookbook/sample-status.md
+++ b/doc/cookbook/sample-status.md
@@ -3,10 +3,11 @@
 Worked examples for the Sample Status API, part of the Annotation Service: assigning status
 codes to individual PV samples, reading them back, and using them to filter time-series queries.
 
-> **Verified against:** dp-grpc `rel-1.17.0` (Java `com.ospreydcs:dp-grpc:1.17.0`).
-> The Sample Status API is **new in 1.17.0** and exists in no earlier release.  The domain
-> registry methods (`saveSampleStatusDomain()` / `querySampleStatusDomains()`) are reserved
-> placeholders in that release and return a "not implemented" error.
+> **Verified against:** dp-grpc `1.16.0` (Java `com.ospreydcs:dp-grpc:1.16.0`).
+> The Sample Status API is **new in 1.16.0**, which is not yet released — it is verified
+> against the `main` branch, and exists in no released version.  The domain registry methods
+> (`saveSampleStatusDomain()` / `querySampleStatusDomains()`) are reserved placeholders in
+> that release and return a "not implemented" error.
 
 Reference documentation: [Sample Status API](../../README.md#sample-status-api) and
 [PV Data Query V2 Methods](../../README.md#pv-data-query-v2-methods) (for the


### PR DESCRIPTION
## Problem

`doc/cookbook/sample-status.md` opened with:

> **Verified against:** dp-grpc `rel-1.17.0` (Java `com.ospreydcs:dp-grpc:1.17.0`).
> The Sample Status API is **new in 1.17.0** and exists in no earlier release.

`1.17.0` appears nowhere else in the repo. It contradicts `pom.xml` (`1.16.0`), and there is no `rel-1.17.0` tag or GitHub release — the latest tag is `rel-1.15.0`. A reader taking the header at face value would try to resolve a Maven artifact that does not exist.

## Fix

The Sample Status API (#121) merged after `rel-1.15.0` and will ship in **1.16.0**, the version already in `pom.xml`. The header now names 1.16.0 and states explicitly that it is unreleased and verified against `main`:

> **Verified against:** dp-grpc `1.16.0` (Java `com.ospreydcs:dp-grpc:1.16.0`).
> The Sample Status API is **new in 1.16.0**, which is not yet released — it is verified
> against the `main` branch, and exists in no released version.  The domain registry methods
> (`saveSampleStatusDomain()` / `querySampleStatusDomains()`) are reserved placeholders in
> that release and return a "not implemented" error.

The `rel-` prefix is dropped since no such tag exists yet; the other recipes keep theirs because they cite real tags.

Docs-only change — no proto or generated-code impact.

## Verification

- `mvn compile` — clean
- `python3 tools/check-cookbook-snippets.py` — 97 blocks from 9 docs, no unresolved types or syntax errors
- `grep` confirms no remaining `1.17` reference anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013e6sv17GpY6G5Bum2jiFaf