### PR TITLE
docs: replace per-recipe "verified against" headers with durable version notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,13 +209,21 @@ time ranges). Recipes **link to `conventions.md` rather than repeating it**.
 Recipe structure, established by `machine-configuration.md`:
 
 1. H1 title, then a one-or-two sentence statement of what it covers
-2. A `> **Verified against:** dp-grpc rel-X.Y.Z` blockquote — state the release the recipe
-   was checked against, and call out any method that does not exist in that release
-3. Reference links to the relevant `README.md` anchors and to `conventions.md`
-4. An imports block, where the recipe uses deeply nested generated classes
-5. `## Contents`, then `## Model` explaining domain concepts before any code
-6. Task-oriented `##` sections with numbered steps
-7. `## Also worth knowing` for the leftovers
+2. Reference links to the relevant `README.md` anchors and to `conventions.md`
+3. An imports block, where the recipe uses deeply nested generated classes
+4. `## Contents`, then `## Model` explaining domain concepts before any code
+5. Task-oriented `##` sections with numbered steps
+6. `## Also worth knowing` for the leftovers
+
+Recipes do **not** carry a "verified against" header.  Only the latest release is supported, so
+recipes describe the current state of the protos on `main`; a per-recipe "verified against
+rel-X.Y.Z" claim decays at every version bump and asserts a re-verification that generally did
+not happen.  The compile-based checks below are the real guarantee that a recipe matches the
+protos, and the `rel-*` tags are the authority on what any past release contained.
+
+Do add a short blockquote note when a recipe uses a method or message **added in a specific
+release** — "added in 1.15.0 and not available in earlier releases".  That is a durable fact
+about the API rather than a claim about when someone last checked, so it never needs updating.
 
 Conventions:
 

--- a/doc/cookbook/datasets-and-annotations.md
+++ b/doc/cookbook/datasets-and-annotations.md
@@ -3,10 +3,6 @@
 Worked examples for defining DataSets, attaching Annotations and derived Calculations to them,
 and exporting the result to HDF5, CSV, or XLSX — all part of the Annotation Service.
 
-> **Verified against:** dp-grpc `rel-1.14.0` (Java `com.ospreydcs:dp-grpc:1.14.0`).
-> All five methods used here (`saveDataSet`, `queryDataSets`, `saveAnnotation`,
-> `queryAnnotations`, `exportData`) exist in 1.14.0 and their field sets are unchanged in 1.15.0.
-
 Reference documentation: [Data Set API](../../README.md#data-set-api),
 [Data Export Methods](../../README.md#data-export-methods), and
 [Annotation API](../../README.md#annotation-api).

--- a/doc/cookbook/ingestion.md
+++ b/doc/cookbook/ingestion.md
@@ -4,14 +4,13 @@ Worked examples for the Ingestion Service: registering a provider, choosing a ti
 column type, sending data by unary call or stream, and confirming that what you sent actually
 landed in the archive.
 
-> **Verified against:** dp-grpc `rel-1.14.0` (Java `com.ospreydcs:dp-grpc:1.14.0`).
-> All methods and messages in this recipe exist in 1.14.0 and are unchanged in 1.15.0.  (The
-> Query API V2 methods referenced in passing under *Verifying a round trip* are new in 1.15.0.)
-
 Reference documentation: [Provider API](../../README.md#provider-api),
 [PV Data Ingestion Methods](../../README.md#pv-data-ingestion-methods), and
 [Ingestion Request Status API](../../README.md#ingestion-request-status-api).
 Shared response, criteria, and time conventions are in [conventions.md](conventions.md).
+
+> The Query API V2 methods referenced in passing under *Verifying a round trip* were added in
+> 1.15.0 and are not available in earlier releases.
 
 ### Imports used by the examples
 

--- a/doc/cookbook/machine-configuration.md
+++ b/doc/cookbook/machine-configuration.md
@@ -3,9 +3,6 @@
 Worked examples for the Machine Configuration and Configuration Activation APIs, part of the
 Annotation Service.
 
-> **Verified against:** dp-grpc `rel-1.14.0` (Java `com.ospreydcs:dp-grpc:1.14.0`).
-> Field sets for these messages are unchanged in 1.15.0.
-
 Reference documentation: [Machine Configuration API](../../README.md#machine-configuration-api)
 and [Configuration Activation API](../../README.md#configuration-activation-api).
 

--- a/doc/cookbook/provider-registration.md
+++ b/doc/cookbook/provider-registration.md
@@ -4,13 +4,6 @@ Worked examples for registering an ingestion data provider (`registerProvider()`
 Service) and for finding providers and their ingestion statistics after the fact
 (`queryProviders()` and `queryProviderStats()`, Query Service).
 
-> **Verified against:** dp-grpc `rel-1.14.0` (Java `com.ospreydcs:dp-grpc:1.14.0`), and re-checked
-> against the current `1.15.0` tree.  All three methods in this recipe are V1 methods present in
-> 1.14.0; `ingestion.proto` is unchanged between the two releases, and the provider query messages
-> (`QueryProvidersRequest`, `ProviderInfo`, `ProviderStats`) are byte-identical in both.  Nothing
-> here depends on the Query API V2 (`queryBuckets`, `querySamples`, and the `TimeRange` message)
-> added in 1.15.0.
-
 Reference documentation: [Provider API](../../README.md#provider-api) —
 [Provider Registration Methods](../../README.md#provider-registration-methods),
 [Provider Query Methods](../../README.md#provider-query-methods), and

--- a/doc/cookbook/pv-metadata.md
+++ b/doc/cookbook/pv-metadata.md
@@ -3,14 +3,12 @@
 Worked examples for the PV Metadata API, part of the Annotation Service: cataloguing PVs with
 aliases, tags, and attributes, and using that metadata to discover PVs and drive data queries.
 
-> **Verified against:** dp-grpc `rel-1.14.0` (Java `com.ospreydcs:dp-grpc:1.14.0`) for all
-> `DpAnnotationService` PV metadata methods.
-> The final section, [Driving a data query from metadata](#driving-a-data-query-from-metadata),
-> uses **Query API V2**, which was added in **1.15.0** and is *not* available in 1.14.
-
 Reference documentation: [PV Metadata API](../../README.md#pv-metadata-api).  Shared response,
 pagination, criteria, and save-semantics rules live in [conventions.md](conventions.md) and are
 not repeated here.
+
+> The final section, [Driving a data query from metadata](#driving-a-data-query-from-metadata),
+> uses **Query API V2**, which was added in 1.15.0 and is not available in earlier releases.
 
 ### Imports used by the examples
 

--- a/doc/cookbook/python-stubs.md
+++ b/doc/cookbook/python-stubs.md
@@ -85,5 +85,5 @@ numbers are not reused or repurposed.  Stubs generated from a newer dp-grpc rele
 generally interoperate with an older server, and vice versa, with unknown fields ignored.
 
 That said, a client calling a method the deployed server does not implement will get an error
-response — so when following a cookbook recipe, check its **Verified against** note against your
-deployed version.
+response.  The cookbook recipes track the current release, so if you are running an older server,
+check the method against the [README](../../README.md) before relying on it.

--- a/doc/cookbook/query.md
+++ b/doc/cookbook/query.md
@@ -4,17 +4,15 @@ Worked examples for retrieving PV time-series data from the archive with the Que
 choosing between the bucket- and sample-oriented methods, selecting PVs by name, pattern, or
 metadata, paging large results, and migrating an existing V1 client to V2.
 
-> **Verified against:** dp-grpc `rel-1.15.0` (Java `com.ospreydcs:dp-grpc:1.15.0`).
-> The **Query API V2 methods** (`queryBuckets`, `queryBucketsStream`, `querySamples`,
-> `querySamplesStream`) were added in issue #123 and are **new in 1.15.0** — they do **not**
-> exist in `rel-1.14.0`.  The V1 methods (`queryData`, `queryDataStream`,
-> `queryDataBidiStream`, `queryTable`, `queryPvStats`) are present in 1.14.0 and remain
-> available in 1.15.0 for backward compatibility.
-
 Reference documentation: [PV Data Query V2 Methods](../../README.md#pv-data-query-v2-methods),
 [PV Data Query Methods](../../README.md#pv-data-query-methods) (V1), and
 [PV Stats Query Methods](../../README.md#pv-stats-query-methods).  Shared response, paging, and
 criteria rules are in [conventions.md](conventions.md).
+
+> The **Query API V2 methods** (`queryBuckets`, `queryBucketsStream`, `querySamples`,
+> `querySamplesStream`) were added in 1.15.0 and are not available in earlier releases.  The
+> V1 methods (`queryData`, `queryDataStream`, `queryDataBidiStream`, `queryTable`,
+> `queryPvStats`) remain available for backward compatibility.
 
 ### Imports used by the examples
 

--- a/doc/cookbook/sample-status.md
+++ b/doc/cookbook/sample-status.md
@@ -3,15 +3,12 @@
 Worked examples for the Sample Status API, part of the Annotation Service: assigning status
 codes to individual PV samples, reading them back, and using them to filter time-series queries.
 
-> **Verified against:** dp-grpc `rel-1.17.0` (Java `com.ospreydcs:dp-grpc:1.17.0`).
-> The Sample Status API is **new in 1.17.0** and exists in no earlier release.  The domain
-> registry methods (`saveSampleStatusDomain()` / `querySampleStatusDomains()`) are reserved
-> placeholders in that release and return a "not implemented" error.
-
 Reference documentation: [Sample Status API](../../README.md#sample-status-api) and
 [PV Data Query V2 Methods](../../README.md#pv-data-query-v2-methods) (for the
 `sampleStatusSelector`).  Response checking, paging, and time-range semantics follow the
 patterns in [conventions.md](conventions.md).
+
+> The Sample Status API was added in 1.16.0 and is not available in earlier releases.
 
 ### Imports used by the examples
 
@@ -308,6 +305,10 @@ with an `ExceptionalResult`.
 - **Whole-request validation.**  A save is validated and rejected as a whole — no partial save
   on rejection.  A mid-write *error* on a valid request may leave some frames persisted; the
   per-status upsert makes retrying the whole request safe.
+- **The status domain registry methods are not yet implemented.**
+  `saveSampleStatusDomain()` and `querySampleStatusDomains()` are reserved placeholders and
+  return a "not implemented" error.  Domains are used simply by naming them, as the recipes
+  above do; there is no registration step.
 - The Sample Status API is the designated replacement for the deprecated `DataValue`
   `ValueStatus` mechanism: capture acquisition-time alarm/status information (e.g. EPICS
   severity and status) as sample statuses in a status domain instead.

--- a/doc/cookbook/subscriptions.md
+++ b/doc/cookbook/subscriptions.md
@@ -4,13 +4,12 @@ Worked examples for the two live-data subscription methods: `DpIngestionService.
 which tails new data for a list of PVs, and `DpIngestionStreamService.subscribeDataEvent()`, which
 fires when a PV condition is met and can capture a window of data around the trigger.
 
-> **Verified against:** dp-grpc `rel-1.14.0` (Java `com.ospreydcs:dp-grpc:1.14.0`).
-> Both methods and all messages used here are unchanged in 1.15.0.  The Query API V2 methods
-> referenced in passing (`queryBuckets`) are new in 1.15.0 and are *not* available in 1.14.
-
 Reference documentation: [PV Data Subscription Methods](../../README.md#pv-data-subscription-methods)
 and [PV Data Event Subscription Methods](../../README.md#pv-data-event-subscription-methods).
 Shared response-checking rules are in [conventions.md](conventions.md).
+
+> The Query API V2 method referenced in passing (`queryBuckets`) was added in 1.15.0 and is
+> not available in earlier releases.
 
 ## Contents
 


### PR DESCRIPTION
Supersedes #140.

## Problem

`doc/cookbook/sample-status.md` opened with:

> **Verified against:** dp-grpc `rel-1.17.0` (Java `com.ospreydcs:dp-grpc:1.17.0`).
> The Sample Status API is **new in 1.17.0** and exists in no earlier release.

`1.17.0` exists nowhere — not in `pom.xml` (`1.16.0`), not as a tag, not as a release. A reader would try to resolve a Maven artifact that does not exist.

#140 corrected the number. But the number was a symptom: the **"Verified against" convention itself** is the problem. It asserts *when someone last checked a recipe*, so it decays at every version bump. Six of eight recipes were still pinned to `rel-1.14.0`, two releases back, and nobody had re-read them. Mechanically stamping them to the current pom would have been worse — asserting a verification that never happened, which is the same error as 1.17.0, only harder to spot because the number looks right.

## Change

Only the latest release is supported, so recipes now simply describe the current protos, and the `rel-*` tags stay the authority on what any past release contained — so nothing here is unrecoverable.

**Durable facts are kept.** Where a recipe uses something added in a specific release, that is now a short note in the body:

> The **Query API V2 methods** (`queryBuckets`, `queryBucketsStream`, `querySamples`,
> `querySamplesStream`) were added in 1.15.0 and are not available in earlier releases.

That is a fact about the API, not about when someone last looked, so it never needs updating. Kept in `query.md`, `pv-metadata.md`, `ingestion.md`, `subscriptions.md`, and `sample-status.md`.

**What was dropped** is the decaying half — "verified against rel-1.14.0", "unchanged in 1.15.0" — which for an additive API is the default and tells a reader nothing actionable.

Also in this PR:

- `sample-status.md`: the deferred-stub note (`saveSampleStatusDomain()` / `querySampleStatusDomains()` return "not implemented") moves from the header into `## Also worth knowing`. It is an API fact that happened to live in a version header; verified against `annotation.proto:440-453`.
- `CLAUDE.md`: the recipe-structure rule mandated the blockquote as step 2. It now says not to carry a "verified against" header, and to add an "added in X" note where one genuinely applies.
- `python-stubs.md`: pointed readers at the header to check server compatibility; now points at the README.

Docs-only — no proto or generated-code impact.

## Verification

- `mvn compile` — clean
- `python3 tools/check-cookbook-snippets.py` — 97 blocks from 9 docs, no unresolved types or syntax errors
- No `1.17` reference remains anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013e6sv17GpY6G5Bum2jiFaf